### PR TITLE
Parse the output of pkg-config in a more reliable way.

### DIFF
--- a/gtk-sys/build.rs
+++ b/gtk-sys/build.rs
@@ -51,7 +51,7 @@ fn main() {
 
     // build include path
     let mut gcc_conf = Config::new();
-    for s in output.split(' ') {
+    for s in output.split_whitespace() {
         if s.starts_with("-I") {
             let path: &Path = s[2..].as_ref();
             gcc_conf.include(path);


### PR DESCRIPTION
On OpenBSD (and maybe other platforms), pkg-config can return a trailing newline
character. This then led the build script to think the last include directory
was "/usr/local/lib/glib-2.0/include\n" -- notice the \n! -- which wasn't found,
leading to a build error. Switching from split(' ') to split_whitespace() solves
the problem nicely, as the latter guarantees to strip out whitespace.