### PR TITLE
Fix the build of popover_menu.

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -120,6 +120,8 @@ pub use self::recent_chooser_widget::RecentChooserWidget;
 pub use self::combo_box::ComboBox;
 #[cfg(gtk_3_12)]
 pub use self::popover::Popover;
+#[cfg(gtk_3_16)]
+pub use self::popover_menu::PopoverMenu;
 pub use self::combo_box_text::ComboBoxText;
 //pub use self::gtype::g_type;
 pub use self::text_mark::TextMark;
@@ -258,6 +260,8 @@ mod recent_chooser_widget;
 mod combo_box;
 #[cfg(gtk_3_12)]
 mod popover;
+#[cfg(gtk_3_16)]
+mod popover_menu;
 mod combo_box_text;
 //mod gtype;
 mod text_mark;

--- a/src/widgets/popover_menu.rs
+++ b/src/widgets/popover_menu.rs
@@ -7,6 +7,8 @@
 use ffi;
 use cast::GTK_POPOVER_MENU;
 
+use glib::translate::ToGlibPtr;
+
 struct_Widget!(PopoverMenu);
 
 impl PopoverMenu {


### PR DESCRIPTION
On a machine with gtk+-3.16 I previously got:

  src/lib.rs:221:5: 221:16 error: unresolved import `self::widgets::PopoverMenu`. There is no `PopoverMenu` in `widgets` [E0432]
  src/lib.rs:221     PopoverMenu
                   ^~~~~~~~~~~

because popover menu was being referenced in lib.rs, but the popover_menu
module was never imported. Once that was fixed, popover_menu didn't quite
compile. This commit fixes both issues.