### PR TITLE
added remove_column method for TreeView

### DIFF
--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -423,6 +423,15 @@ impl TreeView {
         unsafe { ffi::gtk_tree_view_append_column(GTK_TREE_VIEW(self.pointer),
                                                   column.unwrap_pointer()) }
     }
+    
+    pub fn remove_column(&self, column: &::TreeViewColumn) -> i32 {
+        unsafe { 
+            ffi::gtk_tree_view_remove_column(
+                GTK_TREE_VIEW(self.pointer),
+                column.unwrap_pointer()
+            ) 
+       }
+    }
 }
 
 impl_drop!(TreeView);


### PR DESCRIPTION
Hey guys, it seems that `remove_column` was missing for the `TreeView`. 

It also needs `get_columns` but I'm not sure how you guys handle `GList`'s so left for someone else to implement that.