### PR TITLE
`=` in dependencies is too restrictive

### DIFF
--- a/gtk-sys/Cargo.toml
+++ b/gtk-sys/Cargo.toml
@@ -27,5 +27,5 @@ libc = "0.1"
 pango-sys = { git = "https://github.com/gtk-rs/sys" }
 
 [build-dependencies]
-gcc = "=0.3.9"
+gcc = "~0.3.9"
 pkg-config = "0.3.5"


### PR DESCRIPTION
with `~` all versions up to but not including `0.4.0` are okay.