### PR TITLE
Implement signal trait for GLArea

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -55,12 +55,6 @@ use {
     WidgetHelpType,
 };
 
-#[cfg(gtk_3_16)]
-use {
-    gdk,
-    GLArea,
-};
-
 /// Whether to propagate the signal to other handlers
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Inhibit(pub bool);
@@ -1365,12 +1359,6 @@ extern "C" fn tree_view_column_trampoline(this: *mut GtkTreeViewColumn,
 }
 
 #[cfg(gtk_3_16)]
-pub trait GLAreaSignals {
-    fn connect_render<F: Fn(GLArea, gdk::GLContext) -> Inhibit + 'static>(&self, f: F) -> u64;
-    fn connect_resize<F: Fn(GLArea, i32, i32) + 'static>(&self, f: F) -> u64;
-}
-
-#[cfg(gtk_3_16)]
 mod gl_area {
     use std::mem::transmute;
     use glib::signal::connect;
@@ -1384,8 +1372,8 @@ mod gl_area {
     use super::Inhibit;
     use GLArea;
 
-    impl super::GLAreaSignals for GLArea {
-        fn connect_render<F: Fn(GLArea, gdk::GLContext) -> Inhibit + 'static>(&self, f: F) -> u64 {
+    impl GLArea {
+        pub fn connect_render<F: Fn(GLArea, gdk::GLContext) -> Inhibit + 'static>(&self, f: F) -> u64 {
             unsafe {
                 let f: Box<Box<Fn(GLArea, gdk::GLContext) -> Inhibit + 'static>> = Box::new(Box::new(f));
                 connect(self.unwrap_widget() as *mut _,"render",
@@ -1393,7 +1381,7 @@ mod gl_area {
             }
         }
 
-        fn connect_resize<F: Fn(GLArea, i32, i32) + 'static>(&self, f: F) -> u64 {
+        pub fn connect_resize<F: Fn(GLArea, i32, i32) + 'static>(&self, f: F) -> u64 {
             unsafe {
                 let f: Box<Box<Fn(GLArea, i32, i32) + 'static>> = Box::new(Box::new(f));
                 connect(self.unwrap_widget() as *mut _,"resize",

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -55,9 +55,6 @@ pub use signal::{
     ToolButtonSignals,
 };
 
-#[cfg(gtk_3_16)]
-pub use signal::GLAreaSignals;
-
 pub mod style_provider;
 pub mod widget;
 pub mod container;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -55,6 +55,9 @@ pub use signal::{
     ToolButtonSignals,
 };
 
+#[cfg(gtk_3_16)]
+pub use signal::GLAreaSignals;
+
 pub mod style_provider;
 pub mod widget;
 pub mod container;


### PR DESCRIPTION
Looked into what was needed to get a simple example with GtkGLArea working, had to change the signal names and expose the appropriate trait similar to other widgets. Was able to set up opengl using a dummy invisible glutin window and draw to the widget after setting this up.

Can clean up my example and submit a PR to the examples repo if you're interested. Right now it just uses gl::ClearColor to paint the whole widget red, looking into getting a triangle up akin to the example at https://www.bassi.io/articles/2015/02/17/using-opengl-with-gtk/