### PR TITLE
Add safety checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - libgtk-3-dev
 script:
   - rustc --version
+  - ./check_init_asserts
   - mkdir .cargo
   - echo 'paths = ["."]' > .cargo/config
   - git clone -q --depth 50 -b pending https://github.com/rust-gnome/examples _examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly
+  - beta
   - stable
 env:
   - GTK=3.4

--- a/check_init_asserts
+++ b/check_init_asserts
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+perl -0777 -ne 'BEGIN { $e = 0 } while (/^(?!\s*\/\/|\s*unsafe|\s*pub unsafe)(\N*) fn (\w+)(<.*>)?(\((?!&\s*self|&\x27\w+\s+self|&mut\s+self|&\x27\w+\s+mut\s+self)[^{;]+)\{(\s+)(?!assert_init|assert_not_init|skip_assert_init)\S/gms) { print "$ARGV: $2$4\n"; $e = 1 }; END { exit $e }' src/rt.rs src/traits/*.rs src/widgets/*.rs

--- a/check_init_asserts
+++ b/check_init_asserts
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 perl -0777 -ne 'BEGIN { $e = 0 } while (/^(?!\s*\/\/|\s*unsafe|\s*pub unsafe)(\N*) fn (\w+)(<.*>)?(\((?!&\s*self|&\x27\w+\s+self|&mut\s+self|&\x27\w+\s+mut\s+self)[^{;]+)\{(\s+)(?!assert_init|assert_not_init|skip_assert_init)\S/gms) { print "$ARGV: $2$4\n"; $e = 1 }; END { exit $e }' src/rt.rs src/traits/*.rs src/widgets/*.rs
+perl -0777 -ne 'BEGIN { $e = 0 } while (/^(?!\s*\/\/|\s*unsafe|\s*pub unsafe)(\N*) fn (\w+)(<.*>)?(\((?!&\s*self|&\x27\w+\s+self|&mut\s+self|&\x27\w+\s+mut\s+self)[^{;]+)\{(\s+)(?!callback_guard)\S/gms) { print "$ARGV: $2$4\n"; $e = 1 }; END { exit $e }' src/signal.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub use glib::ValuePublic;
 // These are/should be inlined
 pub use self::rt::{
     init,
+    set_initialized,
     main,
     main_quit,
     main_level,
@@ -367,9 +368,11 @@ pub use self::types::{
     Tooltip,
 };
 
+#[macro_use]
+mod rt;
+
 mod macros;
 mod cast;
-mod rt;
 
 pub mod traits;
 pub mod signal;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,10 +37,8 @@ macro_rules! impl_TraitObject(
                 self.pointer as *mut ::gobject_ffi::GObject
             }
 
-            fn wrap_object(object: *mut ::gobject_ffi::GObject) -> $gtk_struct {
-                unsafe{
-                    ::gobject_ffi::g_object_ref(object as *mut _);
-                }
+            unsafe fn wrap_object(object: *mut ::gobject_ffi::GObject) -> $gtk_struct {
+                ::gobject_ffi::g_object_ref(object as *mut _);
 
                 $gtk_struct {
                     pointer: object as *mut ffi::$ffi_type
@@ -78,10 +76,8 @@ macro_rules! impl_TraitWidget(
                 ::cast::G_OBJECT(self.unwrap_widget())
             }
 
-            fn wrap_object(object: *mut ::gobject_ffi::GObject) -> $gtk_struct {
-                unsafe{
-                    ::gobject_ffi::g_object_ref(object as *mut _);
-                }
+            unsafe fn wrap_object(object: *mut ::gobject_ffi::GObject) -> $gtk_struct {
+                ::gobject_ffi::g_object_ref(object as *mut _);
 
                 $gtk_struct {
                     pointer: object as *mut ffi::GtkWidget

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -103,7 +103,12 @@ pub fn main() {
 pub fn main_quit() {
     assert_initialized_main_thread!();
     unsafe {
-        ffi::gtk_main_quit();
+        if ffi::gtk_main_level() > 0 {
+            ffi::gtk_main_quit();
+        }
+        else if cfg!(debug_assertions) {
+            panic!("Attempted to quit a GTK main loop when none is running.");
+        }
     }
 }
 

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -2,11 +2,75 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use libc::c_uint;
+use std::cell::Cell;
 use std::ptr;
+use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+use libc::c_uint;
 use ffi;
-use glib::translate::{from_glib_none};
+use glib::translate::{from_glib, from_glib_none};
 use glib::{to_bool, to_gboolean};
+use gdk;
+
+thread_local! {
+    static IS_MAIN_THREAD: Cell<bool> = Cell::new(false)
+}
+
+static INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
+
+/// Asserts that this is the main thread and `gtk::init` has been called.
+macro_rules! assert_initialized_main_thread {
+    () => (
+        if !::rt::is_initialized_main_thread() {
+            if ::rt::is_initialized() {
+                panic!("GTK may only be used from the main thread.");
+            }
+            else {
+                panic!("GTK has not been initialized. Call `gtk::init` first.");
+            }
+        }
+    )
+}
+
+/// No-op.
+macro_rules! skip_assert_initialized {
+    () => ()
+}
+
+/// Asserts that `gtk::init` has not been called.
+macro_rules! assert_not_initialized {
+    () => (
+        if ::rt::is_initialized() {
+            panic!("This function has to be called before `gtk::init`.");
+        }
+    )
+}
+
+/// Returns `true` if GTK has been initialized.
+#[inline]
+pub fn is_initialized() -> bool {
+    skip_assert_initialized!();
+    INITIALIZED.load(Ordering::Acquire)
+}
+
+/// Returns `true` if GTK has been initialized and this is the main thread.
+#[inline]
+pub fn is_initialized_main_thread() -> bool {
+    skip_assert_initialized!();
+    IS_MAIN_THREAD.with(|c| c.get())
+}
+
+/// Informs this crate that GTK has been initialized and the current thread is the main one.
+pub unsafe fn set_initialized() {
+    skip_assert_initialized!();
+    if is_initialized_main_thread() {
+        return;
+    }
+    else if is_initialized() {
+        panic!("Attempted to initialize GTK from two different threads.");
+    }
+    INITIALIZED.store(true, Ordering::Release);
+    IS_MAIN_THREAD.with(|c| c.set(true));
+}
 
 /// Call this function before using any other GTK+ functions.
 ///
@@ -15,77 +79,95 @@ use glib::{to_bool, to_gboolean};
 /// Instead, an Ok is returned if the windowing system was successfully
 /// initialized otherwise an Err is returned.
 pub fn init() -> Result<(), ()> {
+    assert_not_initialized!();
     unsafe {
-	match to_bool(ffi::gtk_init_check(ptr::null_mut(), ptr::null_mut())) {
-	    true => Ok(()),
-	    false => Err(())
-	}
+        let ok = from_glib(ffi::gtk_init_check(ptr::null_mut(), ptr::null_mut()));
+        if ok {
+            gdk::set_initialized();
+            set_initialized();
+            Ok(())
+        }
+        else {
+            Err(())
+        }
     }
 }
 
 pub fn main() {
+    assert_initialized_main_thread!();
     unsafe {
         ffi::gtk_main();
     }
 }
 
 pub fn main_quit() {
+    assert_initialized_main_thread!();
     unsafe {
         ffi::gtk_main_quit();
     }
 }
 
 pub fn main_level() -> u32 {
+    assert_initialized_main_thread!();
     unsafe {
         ffi::gtk_main_level() as u32
     }
 }
 
 pub fn main_iteration() -> bool {
+    assert_initialized_main_thread!();
     unsafe { to_bool(ffi::gtk_main_iteration()) }
 }
 
 pub fn main_iteration_do(blocking: bool) -> bool {
+    assert_initialized_main_thread!();
     unsafe { to_bool(ffi::gtk_main_iteration_do(to_gboolean(blocking))) }
 }
 
 pub fn events_pending() -> bool {
+    assert_initialized_main_thread!();
     unsafe {
         to_bool(ffi::gtk_events_pending())
     }
 }
 
 pub fn get_major_version() -> u32 {
+    skip_assert_initialized!();
     unsafe {
         ffi::gtk_get_major_version() as u32
     }
 }
 
 pub fn get_minor_version() -> u32 {
+    skip_assert_initialized!();
     unsafe {
         ffi::gtk_get_minor_version() as u32
     }
 }
 
 pub fn get_micro_version() -> u32 {
+    skip_assert_initialized!();
     unsafe {
         ffi::gtk_get_micro_version() as u32
     }
 }
 
 pub fn get_binary_age() -> u32 {
+    skip_assert_initialized!();
     unsafe {
         ffi::gtk_get_binary_age() as u32
     }
 }
 
 pub fn get_interface_age() -> u32 {
+    skip_assert_initialized!();
     unsafe {
         ffi::gtk_get_interface_age() as u32
     }
 }
 
 pub fn check_version(required_major: u32, required_minor: u32, required_micro: u32) -> Option<String> {
+    skip_assert_initialized!();
     unsafe {
         from_glib_none(
             ffi::gtk_check_version(required_major as c_uint, required_minor as c_uint, required_micro as c_uint))

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -4,6 +4,8 @@
 
 //use std::boxed::into_raw;
 use std::mem::transmute;
+use std::process;
+use std::thread;
 
 use glib::signal::connect;
 use glib::translate::*;
@@ -67,6 +69,25 @@ impl ToGlib for Inhibit {
     fn to_glib(&self) -> gboolean {
         self.0.to_glib()
     }
+}
+
+struct CallbackGuard;
+
+impl Drop for CallbackGuard {
+    fn drop(&mut self) {
+        if thread::panicking() {
+            process::exit(101);
+        }
+    }
+}
+
+macro_rules! callback_guard {
+    () => (
+        let _guard = CallbackGuard;
+        if cfg!(debug_assertions) {
+            assert_initialized_main_thread!();
+        }
+    )
 }
 
 // libstd stability workaround
@@ -145,6 +166,7 @@ mod widget {
     use glib_ffi::gboolean;
     use ffi::{GtkWidget, GtkTooltip};
     use {Widget, DirectionType, StateFlags, TextDirection, Tooltip, WidgetHelpType};
+    use super::CallbackGuard;
     use super::Inhibit;
 
     impl<T: FFIWidget + WidgetTrait> super::WidgetSignals for T {
@@ -571,141 +593,170 @@ mod widget {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkWidget, f: &Box<Fn(Widget) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this));
     }
 
     extern "C" fn bool_trampoline(this: *mut GtkWidget, f: &Box<Fn(Widget) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this)).to_glib()
     }
 
     extern "C" fn accel_trampoline(this: *mut GtkWidget, signal_id: c_uint,
             f: &Box<Fn(Widget, u64) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), signal_id as u64).to_glib()
     }
 
     extern "C" fn draw_trampoline(this: *mut GtkWidget, cr: *mut cairo_t,
             f: &Box<Fn(Widget, Context) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), from_glib_none(cr)).to_glib() }
     }
 
     extern "C" fn event_any_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventAny) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_button_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventButton) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_configure_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventConfigure) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_crossing_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventCrossing) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_expose_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventExpose) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_focus_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventFocus) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_grab_broken_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventGrabBroken) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_key_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventKey) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_motion_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventMotion) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_property_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventProperty) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_proximity_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventProximity) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_scroll_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventScroll) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn event_window_state_trampoline(this: *mut GtkWidget, event: *mut EventAny,
             f: &Box<Fn(Widget, &EventWindowState) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(event)).to_glib() }
     }
 
     extern "C" fn direction_trampoline(this: *mut GtkWidget, direction: DirectionType,
             f: &Box<Fn(Widget, DirectionType) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), direction).to_glib()
     }
 
     extern "C" fn direction_void_trampoline(this: *mut GtkWidget, direction: DirectionType,
             f: &Box<Fn(Widget, DirectionType) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), direction);
     }
 
     extern "C" fn grab_trampoline(this: *mut GtkWidget, was_grabbed: gboolean,
             f: &Box<Fn(Widget, bool) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), from_glib(was_grabbed));
     }
 
     extern "C" fn help_trampoline(this: *mut GtkWidget, help_type: WidgetHelpType,
             f: &Box<Fn(Widget, WidgetHelpType) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), help_type).to_glib()
     }
 
     extern "C" fn mnemonic_trampoline(this: *mut GtkWidget, arg1: gboolean,
             f: &Box<Fn(Widget, bool) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), from_glib(arg1)).to_glib()
     }
 
     extern "C" fn notify_trampoline(this: *mut GtkWidget, pspec: *mut ParamSpec,
             f: &Box<Fn(Widget, &ParamSpec) + 'static>) {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(pspec)); }
     }
 
     extern "C" fn query_trampoline(this: *mut GtkWidget, x: c_int, y: c_int, keyboard: gboolean,
-            _tooltip: *mut GtkTooltip, f: &Box<Fn(Widget, i32, i32, bool, Tooltip) -> bool + 'static>)
+            _tooltip: *mut GtkTooltip,
+            f: &Box<Fn(Widget, i32, i32, bool, Tooltip) -> bool + 'static>)
             -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), x, y, from_glib(keyboard), Tooltip).to_glib()
     }
 
     extern "C" fn rectangle_trampoline(this: *mut GtkWidget, allocation: *mut RectangleInt,
             f: &Box<Fn(Widget, &RectangleInt) + 'static>) {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), transmute(allocation)); }
     }
 
     extern "C" fn state_trampoline(this: *mut GtkWidget, flags: StateFlags,
             f: &Box<Fn(Widget, StateFlags) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), flags);
     }
 
     extern "C" fn screen_trampoline(this: *mut GtkWidget, screen: *mut GdkScreen,
             f: &Box<Fn(Widget, Screen) + 'static>) {
+        callback_guard!();
         unsafe { f(FFIWidget::wrap_widget(this), Screen::from_glib_none(screen)); }
     }
 
     extern "C" fn text_direction_trampoline(this: *mut GtkWidget, previous: TextDirection,
             f: &Box<Fn(Widget, TextDirection) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this), previous);
     }
 
@@ -733,6 +784,7 @@ mod entry {
     use libc::c_char;
     use traits::{FFIWidget, EntryTrait};
     use ffi::GtkEntry;
+    use super::CallbackGuard;
     use {Entry, DeleteType, MovementStep};
 
     impl<T: FFIWidget + EntryTrait> super::EntrySignals for T {
@@ -818,22 +870,26 @@ mod entry {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkEntry, f: &Box<Fn(Entry) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 
     extern "C" fn delete_trampoline(this: *mut GtkEntry, delete_type: DeleteType, count: i32,
                                     f: &Box<Fn(Entry, DeleteType, i32) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), delete_type, count);
     }
 
     extern "C" fn move_cursor_trampoline(this: *mut GtkEntry, step: MovementStep, count: i32,
                                          extend_selection: bool,
                                          f: &Box<Fn(Entry, MovementStep, i32, bool) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), step, count, extend_selection);
     }
 
     extern "C" fn string_trampoline(this: *mut GtkEntry, c_str: *const c_char,
                                     f: &Box<Fn(Entry, &str) + 'static>) {
+        callback_guard!();
         let buf = unsafe { CStr::from_ptr(c_str).to_bytes() };
         let string = str::from_utf8(buf).unwrap();
         f(FFIWidget::wrap_widget(this as *mut _), string);
@@ -851,6 +907,7 @@ mod button {
     use glib::signal::connect;
     use traits::{FFIWidget, ButtonTrait};
     use ffi::GtkButton;
+    use super::CallbackGuard;
     use Button;
 
     impl<T: FFIWidget + ButtonTrait> super::ButtonSignals for T {
@@ -872,6 +929,7 @@ mod button {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkButton, f: &Box<Fn(Button) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 }
@@ -891,6 +949,7 @@ mod combobox {
     use glib_ffi::gboolean;
     use ffi::GtkComboBox;
     use traits::{FFIWidget, ComboBoxTrait};
+    use super::CallbackGuard;
     use {ComboBox, ScrollType};
 
     impl<T: FFIWidget + ComboBoxTrait> super::ComboBoxSignals for T {
@@ -928,16 +987,19 @@ mod combobox {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkComboBox, f: &Box<Fn(ComboBox) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 
     extern "C" fn bool_trampoline(this: *mut GtkComboBox, f: &Box<Fn(ComboBox) -> bool + 'static>)
             -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _)).to_glib()
     }
 
     extern "C" fn move_trampoline(this: *mut GtkComboBox, scroll_type: ScrollType,
             f: &Box<Fn(ComboBox, ScrollType) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), scroll_type);
     }
 }
@@ -952,6 +1014,7 @@ mod tool_button {
     use glib::signal::connect;
     use traits::{FFIWidget, ToolButtonTrait};
     use ffi::GtkToolButton;
+    use super::CallbackGuard;
     use ToolButton;
 
     impl<T: FFIWidget + ToolButtonTrait> super::ToolButtonSignals for T {
@@ -965,6 +1028,7 @@ mod tool_button {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkToolButton, f: &Box<Fn(ToolButton) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 }
@@ -980,6 +1044,7 @@ mod spin_button {
     use glib::signal::connect;
     use traits::FFIWidget;
     use ffi::GtkSpinButton;
+    use super::CallbackGuard;
     use SpinButton;
 
     impl super::SpinButtonSignals for SpinButton {
@@ -1001,6 +1066,7 @@ mod spin_button {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkSpinButton, f: &Box<Fn(SpinButton) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 }
@@ -1017,6 +1083,7 @@ mod dialog {
     use glib::signal::connect;
     use traits::{FFIWidget, DialogTrait};
     use ffi::GtkDialog;
+    use super::CallbackGuard;
     use Dialog;
 
     impl<T: FFIWidget + DialogTrait> super::DialogSignals for T {
@@ -1038,11 +1105,13 @@ mod dialog {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkDialog, f: &Box<Fn(Dialog) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 
     extern "C" fn int_trampoline(this: *mut GtkDialog, response: c_int,
             f: &Box<Fn(Dialog, i32) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), response);
     }
 }
@@ -1075,6 +1144,7 @@ mod tree_view {
     use traits::FFIWidget;
     use glib_ffi::gboolean;
     use ffi::{GtkTreeIter, GtkTreePath, GtkTreeView, GtkTreeViewColumn};
+    use super::CallbackGuard;
     use {TreeIter, TreePath, TreeView, TreeViewColumn};
 
     impl super::TreeViewSignals for TreeView {
@@ -1197,27 +1267,33 @@ mod tree_view {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkTreeView, f: &Box<Fn(TreeView) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 
     extern "C" fn bool_trampoline(this: *mut GtkTreeView, f: &Box<Fn(TreeView) -> bool + 'static>)
             -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _)).to_glib()
     }
 
     extern "C" fn bool_bool_trampoline(this: *mut GtkTreeView, arg1: gboolean,
             f: &Box<Fn(TreeView, bool) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), from_glib(arg1)).to_glib()
     }
 
     extern "C" fn bool3_bool_trampoline(this: *mut GtkTreeView, arg1: gboolean, arg2: gboolean,
             arg3: gboolean, f: &Box<Fn(TreeView, bool, bool, bool) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), from_glib(arg1), from_glib(arg2),
             from_glib(arg3)).to_glib()
     }
 
     extern "C" fn path_column_trampoline(this: *mut GtkTreeView, path: *mut GtkTreePath,
-            column: *mut GtkTreeViewColumn, f: &Box<Fn(TreeView, TreePath, TreeViewColumn) + 'static>) {
+            column: *mut GtkTreeViewColumn,
+            f: &Box<Fn(TreeView, TreePath, TreeViewColumn) + 'static>) {
+        callback_guard!();
         unsafe {
             f(FFIWidget::wrap_widget(this as *mut _), TreePath::wrap_pointer(path),
                 TreeViewColumn::wrap_pointer(column));
@@ -1226,6 +1302,7 @@ mod tree_view {
 
     extern "C" fn iter_path_trampoline(this: *mut GtkTreeView, iter: *mut GtkTreeIter,
             path: *mut GtkTreePath, f: &Box<Fn(TreeView, &mut TreeIter, TreePath) + 'static>) {
+        callback_guard!();
         unsafe {
             f(FFIWidget::wrap_widget(this as *mut _), &mut from_glib_borrow(iter),
                 TreePath::wrap_pointer(path));
@@ -1234,8 +1311,8 @@ mod tree_view {
 
     extern "C" fn iter_path_bool_trampoline(this: *mut GtkTreeView, iter: *mut GtkTreeIter,
             path: *mut GtkTreePath,
-            f: &Box<Fn(TreeView, &mut TreeIter, TreePath) -> bool + 'static>)
-            -> gboolean {
+            f: &Box<Fn(TreeView, &mut TreeIter, TreePath) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         unsafe {
             f(FFIWidget::wrap_widget(this as *mut _), &mut from_glib_borrow(iter),
                 TreePath::wrap_pointer(path)).to_glib()
@@ -1260,6 +1337,7 @@ mod range {
     use glib_ffi::gboolean;
     use ffi::{GtkRange};
     use {Range, ScrollType};
+    use super::CallbackGuard;
     use super::Inhibit;
 
     impl<T: FFIWidget + RangeTrait> super::RangeSignals for T {
@@ -1298,21 +1376,25 @@ mod range {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkRange, f: &Box<Fn(Range) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 
     extern "C" fn adjust_trampoline(this: *mut GtkRange, value: c_double,
             f: &Box<Fn(Range, f64) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), value);
     }
 
     extern "C" fn change_trampoline(this: *mut GtkRange, scroll: ScrollType, value: c_double,
             f: &Box<Fn(Range, ScrollType, f64) -> Inhibit + 'static>) -> gboolean {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), scroll, value).to_glib()
     }
 
     extern "C" fn move_trampoline(this: *mut GtkRange, step: ScrollType,
             f: &Box<Fn(Range, ScrollType) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _), step);
     }
 }
@@ -1328,6 +1410,7 @@ impl Adjustment {
 }
 
 extern "C" fn adjustment_trampoline(this: *mut GtkAdjustment, f: &Box<Fn(Adjustment) + 'static>) {
+        callback_guard!();
     unsafe { f(Adjustment::wrap_pointer(this)) }
 }
 
@@ -1343,6 +1426,7 @@ impl TreeSelection {
 
 extern "C" fn tree_selection_trampoline(this: *mut GtkTreeSelection,
         f: &Box<Fn(TreeSelection) + 'static>) {
+        callback_guard!();
     unsafe { f(TreeSelection::wrap_object(this as *mut _)) }
 }
 
@@ -1358,6 +1442,7 @@ impl TreeViewColumn {
 
 extern "C" fn tree_view_column_trampoline(this: *mut GtkTreeViewColumn,
         f: &Box<Fn(TreeViewColumn) + 'static>) {
+        callback_guard!();
     unsafe { f(TreeViewColumn::wrap_pointer(this)) }
 }
 
@@ -1372,6 +1457,7 @@ mod gl_area {
     use cast::GTK_WIDGET;
     use super::into_raw;
     use traits::FFIWidget;
+    use super::CallbackGuard;
     use super::Inhibit;
     use GLArea;
 
@@ -1396,12 +1482,14 @@ mod gl_area {
     #[cfg(gtk_3_16)]
     extern "C" fn gl_area_trampoline(this: *mut GtkGLArea, context: *mut gdk_ffi::GdkGLContext,
             f: &Box<Fn(GLArea, gdk::GLContext) + 'static>) {
+        callback_guard!();
         unsafe { f(GLArea::wrap_widget(GTK_WIDGET(this as *mut _)), from_glib_none(context)) }
     }
 
     #[cfg(gtk_3_16)]
     extern "C" fn gl_area_trampoline_res(this: *mut GtkGLArea, width: i32, height: i32,
             f: &Box<Fn(GLArea, i32, i32) + 'static>) {
+        callback_guard!();
         f(GLArea::wrap_widget(GTK_WIDGET(this as *mut _)), width, height)
     }
 }
@@ -1422,6 +1510,7 @@ mod calendar {
     use glib::signal::connect;
     use traits::FFIWidget;
     use ffi::GtkCalendar;
+    use super::CallbackGuard;
     use Calendar;
 
     impl super::CalendarSignals for Calendar {
@@ -1483,6 +1572,7 @@ mod calendar {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkCalendar, f: &Box<Fn(Calendar) + 'static>) {
+        callback_guard!();
         f(FFIWidget::wrap_widget(this as *mut _));
     }
 }
@@ -1507,6 +1597,7 @@ mod status_icon {
     use glib::signal::connect;
     use glib::translate::*;
     use glib_ffi::gboolean;
+    use super::CallbackGuard;
     use Tooltip;
 
     impl super::StatusIconSignals for StatusIcon {
@@ -1568,30 +1659,40 @@ mod status_icon {
     }
 
     extern "C" fn void_trampoline(this: *mut GtkStatusIcon, f: &Box<Fn(StatusIcon) + 'static>) {
+        callback_guard!();
         unsafe {
             f(from_glib_none(this));
         }
     }
 
-    extern "C" fn event_trampoline(this: *mut GtkStatusIcon, event: *mut EventButton, f: &Box<Fn(StatusIcon, &EventScroll) -> bool + 'static>) -> gboolean {
+    extern "C" fn event_trampoline(this: *mut GtkStatusIcon, event: *mut EventButton,
+            f: &Box<Fn(StatusIcon, &EventScroll) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         unsafe {
             f(from_glib_none(this), transmute(event)).to_glib()
         }
     }
 
-    extern "C" fn popup_menu_trampoline(this: *mut GtkStatusIcon, button: c_uint, activate_time: c_uint, f: &Box<Fn(StatusIcon, u32, u32) + 'static>) {
+    extern "C" fn popup_menu_trampoline(this: *mut GtkStatusIcon, button: c_uint,
+            activate_time: c_uint, f: &Box<Fn(StatusIcon, u32, u32) + 'static>) {
+        callback_guard!();
         unsafe {
             f(from_glib_none(this), button, activate_time);
         }
     }
 
-    extern "C" fn query_tooltip_trampoline(this: *mut GtkStatusIcon, x: c_int, y: c_int, keyboard_mode: gboolean, _tooltip: *mut GtkTooltip, f: &Box<Fn(StatusIcon, i32, i32, bool, Tooltip) -> bool + 'static>) -> gboolean {
+    extern "C" fn query_tooltip_trampoline(this: *mut GtkStatusIcon, x: c_int, y: c_int,
+            keyboard_mode: gboolean, _tooltip: *mut GtkTooltip,
+            f: &Box<Fn(StatusIcon, i32, i32, bool, Tooltip) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         unsafe {
             f(from_glib_none(this), x, y, from_glib(keyboard_mode), Tooltip).to_glib()
         }
     }
 
-    extern "C" fn size_changed_trampoline(this: *mut GtkStatusIcon, size: c_int, f: &Box<Fn(StatusIcon, i32) -> bool + 'static>) -> gboolean {
+    extern "C" fn size_changed_trampoline(this: *mut GtkStatusIcon, size: c_int,
+            f: &Box<Fn(StatusIcon, i32) -> bool + 'static>) -> gboolean {
+        callback_guard!();
         unsafe {
             f(from_glib_none(this), size).to_glib()
         }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1218,8 +1218,10 @@ mod tree_view {
 
     extern "C" fn path_column_trampoline(this: *mut GtkTreeView, path: *mut GtkTreePath,
             column: *mut GtkTreeViewColumn, f: &Box<Fn(TreeView, TreePath, TreeViewColumn) + 'static>) {
-        f(FFIWidget::wrap_widget(this as *mut _), TreePath::wrap_pointer(path),
-            TreeViewColumn::wrap_pointer(column));
+        unsafe {
+            f(FFIWidget::wrap_widget(this as *mut _), TreePath::wrap_pointer(path),
+                TreeViewColumn::wrap_pointer(column));
+        }
     }
 
     extern "C" fn iter_path_trampoline(this: *mut GtkTreeView, iter: *mut GtkTreeIter,
@@ -1326,7 +1328,7 @@ impl Adjustment {
 }
 
 extern "C" fn adjustment_trampoline(this: *mut GtkAdjustment, f: &Box<Fn(Adjustment) + 'static>) {
-    f(Adjustment::wrap_pointer(this))
+    unsafe { f(Adjustment::wrap_pointer(this)) }
 }
 
 impl TreeSelection {
@@ -1341,7 +1343,7 @@ impl TreeSelection {
 
 extern "C" fn tree_selection_trampoline(this: *mut GtkTreeSelection,
         f: &Box<Fn(TreeSelection) + 'static>) {
-    f(TreeSelection::wrap_object(this as *mut _))
+    unsafe { f(TreeSelection::wrap_object(this as *mut _)) }
 }
 
 impl TreeViewColumn {
@@ -1356,7 +1358,7 @@ impl TreeViewColumn {
 
 extern "C" fn tree_view_column_trampoline(this: *mut GtkTreeViewColumn,
         f: &Box<Fn(TreeViewColumn) + 'static>) {
-    f(TreeViewColumn::wrap_pointer(this))
+    unsafe { f(TreeViewColumn::wrap_pointer(this)) }
 }
 
 #[cfg(gtk_3_16)]

--- a/src/traits/combo_box.rs
+++ b/src/traits/combo_box.rs
@@ -79,13 +79,13 @@ pub trait ComboBoxTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
     }
 
     fn get_model(&self) -> Option<::TreeModel> {
-        let tmp = unsafe { ffi::gtk_combo_box_get_model(GTK_COMBO_BOX(self.unwrap_widget())) };
-
-        if tmp.is_null() {
-            None
-        } else {
-            unsafe { ::gobject_ffi::g_object_ref(tmp as *mut _) };
-            Some(::TreeModel::wrap_pointer(tmp))
+        unsafe {
+            let ptr = ffi::gtk_combo_box_get_model(GTK_COMBO_BOX(self.unwrap_widget()));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(::TreeModel::wrap_pointer(ptr))
+            }
         }
     }
 

--- a/src/traits/entry.rs
+++ b/src/traits/entry.rs
@@ -12,9 +12,10 @@ use glib::{to_bool, to_gboolean};
 
 pub trait EntryTrait: ::WidgetTrait {
     fn get_buffer(&self) -> ::EntryBuffer {
-        let tmp_pointer = unsafe { ffi::gtk_entry_get_buffer(GTK_ENTRY(self.unwrap_widget())) };
-
-        ::EntryBuffer::wrap_pointer(tmp_pointer)
+        unsafe {
+            let ptr = ffi::gtk_entry_get_buffer(GTK_ENTRY(self.unwrap_widget()));
+            ::EntryBuffer::wrap_pointer(ptr)
+        }
     }
 
     fn set_buffer(&self, buffer: &::EntryBuffer) -> () {

--- a/src/traits/file_chooser.rs
+++ b/src/traits/file_chooser.rs
@@ -246,9 +246,10 @@ pub trait FileChooserTrait: ::WidgetTrait {
     }
 
     fn get_filter(&self) -> Option<::FileFilter> {
-        let tmp = unsafe { ffi::gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(self.unwrap_widget())) };
-
-        ::FileFilter::wrap(tmp)
+        unsafe {
+            let ptr = ffi::gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(self.unwrap_widget()));
+            ::FileFilter::wrap(ptr)
+        }
     }
 
     fn add_shortcut_folder(&self, folder: &str, error: &mut glib::Error) -> bool {

--- a/src/traits/recent_chooser.rs
+++ b/src/traits/recent_chooser.rs
@@ -164,8 +164,9 @@ pub trait RecentChooserTrait: ::WidgetTrait + FFIWidget {
     }
 
     fn get_filter(&self) -> Option<::RecentFilter> {
-        let tmp = unsafe { ffi::gtk_recent_chooser_get_filter(GTK_RECENT_CHOOSER(self.unwrap_widget())) };
-
-        ::RecentFilter::wrap(tmp)
+        unsafe {
+            let ptr = ffi::gtk_recent_chooser_get_filter(GTK_RECENT_CHOOSER(self.unwrap_widget()));
+            ::RecentFilter::wrap(ptr)
+        }
     }
 }

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -140,10 +140,12 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
     }
 
     fn set_default_direction(dir: ::TextDirection) {
+        assert_initialized_main_thread!();
         unsafe { ffi::gtk_widget_set_default_direction(dir) }
     }
 
     fn get_default_direction() -> ::TextDirection {
+        assert_initialized_main_thread!();
         unsafe { ffi::gtk_widget_get_default_direction() }
     }
 

--- a/src/widgets/_box.rs
+++ b/src/widgets/_box.rs
@@ -19,6 +19,7 @@ struct_Widget!(Box);
 
 impl Box {
     pub fn new(orientation: Orientation, spacing: i32) -> Option<Box> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_box_new(orientation, spacing as c_int) };
         check_pointer!(tmp_pointer, Box)
     }

--- a/src/widgets/about_dialog.rs
+++ b/src/widgets/about_dialog.rs
@@ -12,6 +12,7 @@ struct_Widget!(AboutDialog);
 
 impl AboutDialog {
     pub fn new() -> Option<AboutDialog> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_about_dialog_new() };
 
         if tmp_pointer.is_null() {
@@ -227,6 +228,7 @@ impl AboutDialog {
     }
 
     /*pub fn show(parent: Window, properties: Vec<String>) -> () {
+        assert_initialized_main_thread!();
         unsafe { ffi::gtk_show_about_dialog(GTK_WINDOW(parent), first_property_name, ...) }
     }*/
 }

--- a/src/widgets/action_bar.rs
+++ b/src/widgets/action_bar.rs
@@ -11,6 +11,7 @@ struct_Widget!(ActionBar);
 
 impl ActionBar {
     pub fn new() -> Option<ActionBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_action_bar_new() };
         check_pointer!(tmp_pointer, ActionBar)
     }

--- a/src/widgets/adjustment.rs
+++ b/src/widgets/adjustment.rs
@@ -153,8 +153,8 @@ impl Adjustment {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_adjustment: *mut ffi::GtkAdjustment) -> Adjustment {
-        unsafe { ::gobject_ffi::g_object_ref(c_adjustment as *mut _); }
+    pub unsafe fn wrap_pointer(c_adjustment: *mut ffi::GtkAdjustment) -> Adjustment {
+        ::gobject_ffi::g_object_ref(c_adjustment as *mut _);
         Adjustment {
             pointer: c_adjustment
         }

--- a/src/widgets/adjustment.rs
+++ b/src/widgets/adjustment.rs
@@ -25,6 +25,7 @@ impl Adjustment {
                step_increment: f64,
                page_increment: f64,
                page_size: f64) -> Option<Adjustment> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_adjustment_new(value as c_double, lower as c_double,
                                                            upper as c_double, step_increment as c_double,
                                                            page_increment as c_double, page_size as c_double) };

--- a/src/widgets/alignment.rs
+++ b/src/widgets/alignment.rs
@@ -17,6 +17,7 @@ impl Alignment {
                y_align: f32,
                x_scale: f32,
                y_scale: f32) -> Option<Alignment> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_alignment_new(x_align as c_float, y_align as c_float, x_scale as c_float, y_scale as c_float) };
         check_pointer!(tmp_pointer, Alignment)
     }

--- a/src/widgets/app_chooser_dialog.rs
+++ b/src/widgets/app_chooser_dialog.rs
@@ -11,6 +11,7 @@ struct_Widget!(AppChooserDialog);
 
 impl AppChooserDialog {
     pub fn new_for_content_type(parent: Option<&::Window>, flags: ::DialogFlags, content_type: &str) -> Option<AppChooserDialog> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             let parent = match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),

--- a/src/widgets/app_chooser_widget.rs
+++ b/src/widgets/app_chooser_widget.rs
@@ -13,6 +13,7 @@ struct_Widget!(AppChooserWidget);
 
 impl AppChooserWidget {
     pub fn new(content_type: &str) -> Option<AppChooserWidget> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_app_chooser_widget_new(content_type.to_glib_none().0)
         };

--- a/src/widgets/app_info.rs
+++ b/src/widgets/app_info.rs
@@ -15,6 +15,7 @@ struct_Widget!(AppInfo);
 
 impl AppInfo {/*
     pub fn create_from_commandline(commande_line: &str, application_name: &str, flag: ::AppInfoCreateFlags, error: &mut glib::Error) -> Option<AppInfo> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             commande_line.with_c_str(|c_command_line| {
                 application_name.with_c_str(|c_application_name| {
@@ -203,6 +204,7 @@ impl AppInfo {/*
     }
 
     pub fn get_all() -> Option<glib::List> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::g_app_info_get_all() };
 
         if tmp_pointer.is_null() {
@@ -213,6 +215,7 @@ impl AppInfo {/*
     }
 
     pub fn get_all_for_type() -> Option<glib::List> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::g_app_info_get_all_for_type() };
 
         if tmp_pointer.is_null() {
@@ -223,6 +226,7 @@ impl AppInfo {/*
     }
 
     pub fn get_default_for_type(content_type: &str, must_support_uris: bool) -> Option<AppInfo> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             content_type.with_c_str(|c_str| {
                 ffi::g_app_info_get_default_for_type(c_str, to_gboolean(must_support_uris)) })
@@ -236,6 +240,7 @@ impl AppInfo {/*
     }
 
     pub fn get_default_for_uri_scheme(uri_scheme: &str) -> Option<AppInfo> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             uri_scheme.with_c_str(|c_str| {
                 ffi::g_app_info_get_default_for_uri_scheme(c_str)
@@ -250,6 +255,7 @@ impl AppInfo {/*
     }
 
     pub fn get_fallback_for_type(content_type: &str) -> Option<glib::List> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             content_type.with_c_str(|c_str| {
                 ffi::g_app_info_get_fallback_for_type(c_str)
@@ -264,6 +270,7 @@ impl AppInfo {/*
     }
 
     pub fn get_recommended_for_type(content_type: &str) -> Option<glib::List> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             content_type.with_c_str(|c_str| {
                 ffi::g_app_info_get_recommended_for_type(c_str)
@@ -278,6 +285,7 @@ impl AppInfo {/*
     }
 
     pub fn launch_default_for_uri(uri: &str, launch_context: &::AppLaunchContext, error: &glib::Error) -> bool {
+        assert_initialized_main_thread!();
         unsafe { to_bool({
             uri.with_c_str(|c_str| {
                 ffi::g_app_info_launch_default_for_uri(c_str, GTK_APP_LAUNCH_CONTEXT(launch_context.unwrap_widget()), &mut error.unwrap())

--- a/src/widgets/app_launch_context.rs
+++ b/src/widgets/app_launch_context.rs
@@ -13,6 +13,7 @@ struct_Widget!(AppLaunchContext);
 
 impl AppLaunchContext {/*
     pub fn new() -> Option<AppLaunchContext> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::g_app_launch_context_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/arrow.rs
+++ b/src/widgets/arrow.rs
@@ -13,6 +13,7 @@ struct_Widget!(Arrow);
 
 impl Arrow {
     pub fn new(arrow_type: ArrowType, shadow_type: ShadowType) -> Option<Arrow> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_arrow_new(arrow_type, shadow_type) };
         check_pointer!(tmp_pointer, Arrow)
     }

--- a/src/widgets/aspect_frame.rs
+++ b/src/widgets/aspect_frame.rs
@@ -16,6 +16,7 @@ struct_Widget!(AspectFrame);
 
 impl AspectFrame {
     pub fn new(label: Option<&str>, x_align: f32, y_align: f32, ratio: f32, obey_child: bool) -> Option<AspectFrame> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_aspect_frame_new(label.to_glib_none().0,
                                       x_align as c_float, y_align as c_float,

--- a/src/widgets/builder.rs
+++ b/src/widgets/builder.rs
@@ -16,6 +16,7 @@ pub struct Builder {
 
 impl Builder {
     pub fn new() -> Option<Builder> {
+        assert_initialized_main_thread!();
         let tmp = unsafe { ffi::gtk_builder_new() };
 
         if tmp.is_null() {
@@ -29,6 +30,7 @@ impl Builder {
 
     #[cfg(gtk_3_10)]
     pub fn new_from_file(file_name: &str) -> Option<Builder> {
+        assert_initialized_main_thread!();
         let tmp = unsafe {
             ffi::gtk_builder_new_from_file(file_name.to_glib_none().0)
         };
@@ -44,6 +46,7 @@ impl Builder {
 
     #[cfg(gtk_3_10)]
     pub fn new_from_resource(resource_path: &str) -> Option<Builder> {
+        assert_initialized_main_thread!();
         let tmp = unsafe {
             ffi::gtk_builder_new_from_resource(resource_path.to_glib_none().0)
         };
@@ -59,6 +62,7 @@ impl Builder {
 
     #[cfg(gtk_3_10)]
     pub fn new_from_string(string: &str) -> Option<Builder> {
+        assert_initialized_main_thread!();
         let tmp = unsafe {
             // Don't need a null-terminated string here
             ffi::gtk_builder_new_from_string(string.as_ptr() as *const c_char,

--- a/src/widgets/builder.rs
+++ b/src/widgets/builder.rs
@@ -75,14 +75,13 @@ impl Builder {
     }
 
     pub fn get_object<T: GObjectTrait>(&self, name: &str) -> Option<T> {
-        let tmp = unsafe {
-            ffi::gtk_builder_get_object(self.pointer, name.to_glib_none().0)
-        };
-
-        if tmp.is_null() {
-            None
-        } else {
-            Some(::glib::traits::FFIGObject::wrap_object(tmp))
+        unsafe {
+            let ptr = ffi::gtk_builder_get_object(self.pointer, name.to_glib_none().0);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(::glib::traits::FFIGObject::wrap_object(ptr))
+            }
         }
     }
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -23,11 +23,13 @@ struct_Widget!(Button);
 
 impl Button {
     pub fn new() -> Option<Button> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_button_new() };
         check_pointer!(tmp_pointer, Button)
     }
 
     pub fn new_with_label(label: &str) -> Option<Button> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_button_new_with_label(label.to_glib_none().0)
         };
@@ -35,6 +37,7 @@ impl Button {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Button> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_button_new_with_mnemonic(mnemonic.to_glib_none().0)
         };
@@ -43,6 +46,7 @@ impl Button {
 
     #[cfg(gtk_3_10)]
     pub fn new_from_icon_name(icon_name: &str, size: i32) -> Option<Button> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_button_new_from_icon_name(icon_name.to_glib_none().0, size)
         };
@@ -50,6 +54,7 @@ impl Button {
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<Button> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_button_new_from_stock(stock_id.to_glib_none().0)
         };

--- a/src/widgets/button_box.rs
+++ b/src/widgets/button_box.rs
@@ -14,6 +14,7 @@ struct_Widget!(ButtonBox);
 
 impl ButtonBox {
     pub fn new(orientation: Orientation) -> Option<ButtonBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_button_box_new(orientation) };
         check_pointer!(tmp_pointer, ButtonBox)
     }

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -27,6 +27,7 @@ struct_Widget!(Calendar);
 
 impl Calendar {
     pub fn new() -> Option<Calendar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_calendar_new() };
         check_pointer!(tmp_pointer, Calendar)
     }

--- a/src/widgets/cell_renderer_text.rs
+++ b/src/widgets/cell_renderer_text.rs
@@ -11,6 +11,7 @@ struct_Widget!(CellRendererText);
 
 impl CellRendererText {
     pub fn new() -> Option<CellRendererText> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_cell_renderer_text_new() as *mut ffi::GtkWidget };
 
         check_pointer!(tmp_pointer, CellRendererText)

--- a/src/widgets/cell_renderer_toggle.rs
+++ b/src/widgets/cell_renderer_toggle.rs
@@ -11,6 +11,7 @@ struct_Widget!(CellRendererToggle);
 
 impl CellRendererToggle {
     pub fn new() -> Option<CellRendererToggle> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_cell_renderer_toggle_new() as *mut ffi::GtkWidget };
 
         check_pointer!(tmp_pointer, CellRendererToggle)

--- a/src/widgets/check_button.rs
+++ b/src/widgets/check_button.rs
@@ -12,11 +12,13 @@ struct_Widget!(CheckButton);
 
 impl CheckButton {
     pub fn new() -> Option<CheckButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_check_button_new() };
         check_pointer!(tmp_pointer, CheckButton)
     }
 
     pub fn new_with_label(label: &str) -> Option<CheckButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_check_button_new_with_label(label.to_glib_none().0)
         };
@@ -24,6 +26,7 @@ impl CheckButton {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_check_button_new_with_mnemonic(mnemonic.to_glib_none().0)
         };

--- a/src/widgets/check_menu_item.rs
+++ b/src/widgets/check_menu_item.rs
@@ -12,11 +12,13 @@ struct_Widget!(CheckMenuItem);
 
 impl CheckMenuItem {
     pub fn new() -> Option<CheckMenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_check_menu_item_new() };
         check_pointer!(tmp_pointer, CheckMenuItem)
     }
 
     pub fn new_with_label(label: &str) -> Option<CheckMenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_check_menu_item_new_with_label(label.to_glib_none().0)
         };
@@ -24,6 +26,7 @@ impl CheckMenuItem {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<CheckMenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_check_menu_item_new_with_mnemonic(
                     mnemonic.to_glib_none().0)

--- a/src/widgets/color_button.rs
+++ b/src/widgets/color_button.rs
@@ -21,16 +21,19 @@ struct_Widget!(ColorButton);
 
 impl ColorButton {
     pub fn new() -> Option<ColorButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_color_button_new() };
         check_pointer!(tmp_pointer, ColorButton)
     }
 
     pub fn new_with_color(color: &gdk::Color) -> Option<ColorButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_color_button_new_with_color(color) };
         check_pointer!(tmp_pointer, ColorButton)
     }
 
     pub fn new_with_rgba(rgba: &gdk_ffi::GdkRGBA) -> Option<ColorButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_color_button_new_with_rgba(rgba) };
         check_pointer!(tmp_pointer, ColorButton)
     }

--- a/src/widgets/color_chooser_dialog.rs
+++ b/src/widgets/color_chooser_dialog.rs
@@ -11,6 +11,7 @@ struct_Widget!(ColorChooserDialog);
 
 impl ColorChooserDialog {
     pub fn new(title: &str, parent: Option<&::Window>) -> Option<ColorChooserDialog> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_color_chooser_dialog_new(title.to_glib_none().0,
                 match parent {

--- a/src/widgets/color_chooser_widget.rs
+++ b/src/widgets/color_chooser_widget.rs
@@ -11,6 +11,7 @@ struct_Widget!(ColorChooserWidget);
 
 impl ColorChooserWidget {
     pub fn new() -> Option<ColorChooserWidget> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_color_chooser_widget_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/combo_box.rs
+++ b/src/widgets/combo_box.rs
@@ -10,31 +10,37 @@ struct_Widget!(ComboBox);
 
 impl ComboBox {
     pub fn new() -> Option<ComboBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new() };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_entry() -> Option<ComboBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_entry() };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_model(model: &::TreeModel) -> Option<ComboBox> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_model_and_entry(model: &::TreeModel) -> Option<ComboBox> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_model_and_entry(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     /*pub fn new_with_area(area: &::CellArea) -> Option<ComboBox> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area(area.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }
 
     pub fn new_with_area_and_entry(area: &::CellArea) -> Option<ComboBox> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_new_with_area_and_entry(area.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ComboBox)
     }*/

--- a/src/widgets/combo_box_text.rs
+++ b/src/widgets/combo_box_text.rs
@@ -12,11 +12,13 @@ struct_Widget!(ComboBoxText);
 
 impl ComboBoxText {
     pub fn new() -> Option<ComboBoxText> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_text_new() };
         check_pointer!(tmp_pointer, ComboBoxText)
     }
 
     pub fn new_with_entry() -> Option<ComboBoxText> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_combo_box_text_new_with_entry() };
         check_pointer!(tmp_pointer, ComboBoxText)
     }

--- a/src/widgets/css_provider.rs
+++ b/src/widgets/css_provider.rs
@@ -16,14 +16,17 @@ impl ::StyleProviderTrait for CssProvider {}
 
 impl CssProvider {
     pub fn new() -> Self {
+        assert_initialized_main_thread!();
         unsafe { CssProvider { pointer: ffi::gtk_css_provider_new() } }
     }
 
     pub fn get_default() -> Self {
+        assert_initialized_main_thread!();
         unsafe { CssProvider { pointer: ffi::gtk_css_provider_get_default() } }
     }
 
     pub fn get_named(name: &str, variant: &str) -> Self {
+        assert_initialized_main_thread!();
         unsafe {
             CssProvider { pointer: ffi::gtk_css_provider_get_named(name.to_glib_none().0,
                                                                    variant.to_glib_none().0) }
@@ -31,6 +34,7 @@ impl CssProvider {
     }
 
     pub fn load_from_path(path: &str) -> Result<CssProvider, glib::Error> {
+        assert_initialized_main_thread!();
         unsafe {
             let pointer = ffi::gtk_css_provider_new();
             let mut error = ::std::ptr::null_mut();

--- a/src/widgets/dialog.rs
+++ b/src/widgets/dialog.rs
@@ -13,6 +13,7 @@ struct_Widget!(Dialog);
 
 impl Dialog {
     pub fn new() -> Dialog {
+        assert_initialized_main_thread!();
         unsafe {
             ::FFIWidget::wrap_widget(
                 ffi::gtk_dialog_new())
@@ -21,6 +22,7 @@ impl Dialog {
 
     pub fn with_buttons<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                           flags: ::DialogFlags, buttons: T) -> Dialog {
+        assert_initialized_main_thread!();
         unsafe {
             let parent = match parent {
                 Some(w) => GTK_WINDOW(w.unwrap_widget()),

--- a/src/widgets/drawing_area.rs
+++ b/src/widgets/drawing_area.rs
@@ -9,6 +9,7 @@ struct_Widget!(DrawingArea);
 
 impl DrawingArea {
     pub fn new() -> Option<DrawingArea> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_drawing_area_new() };
         check_pointer!(tmp_pointer, DrawingArea)
     }

--- a/src/widgets/entry.rs
+++ b/src/widgets/entry.rs
@@ -27,11 +27,13 @@ struct_Widget!(Entry);
 
 impl Entry {
     pub fn new() -> Option<Entry> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_entry_new() };
         check_pointer!(tmp_pointer, Entry)
     }
 
     pub fn new_with_buffer(buffer: &::EntryBuffer) -> Option<Entry> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_entry_new_with_buffer(buffer.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Entry)
     }

--- a/src/widgets/entry_buffer.rs
+++ b/src/widgets/entry_buffer.rs
@@ -24,6 +24,7 @@ pub struct EntryBuffer {
 
 impl EntryBuffer {
     pub fn new(initial_chars: Option<&str>) -> Option<EntryBuffer> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_entry_buffer_new(initial_chars.to_glib_none().0, -1)
         };

--- a/src/widgets/entry_buffer.rs
+++ b/src/widgets/entry_buffer.rs
@@ -91,7 +91,7 @@ impl EntryBuffer {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(pointer: *mut ffi::GtkEntryBuffer) -> EntryBuffer {
+    pub unsafe fn wrap_pointer(pointer: *mut ffi::GtkEntryBuffer) -> EntryBuffer {
         EntryBuffer {
             pointer:    pointer
         }

--- a/src/widgets/entry_completion.rs
+++ b/src/widgets/entry_completion.rs
@@ -13,6 +13,7 @@ struct_Widget!(EntryCompletion);
 
 impl EntryCompletion {
     pub fn new() -> Option<EntryCompletion> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_entry_completion_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/entry_completion.rs
+++ b/src/widgets/entry_completion.rs
@@ -40,13 +40,13 @@ impl EntryCompletion {
     }
 
     pub fn get_model(&self) -> Option<TreeModel> {
-        let tmp_pointer = unsafe { ffi::gtk_entry_completion_get_model(GTK_ENTRY_COMPLETION(self.pointer)) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { ::gobject_ffi::g_object_ref(tmp_pointer as *mut _) };
-            Some(TreeModel::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_entry_completion_get_model(GTK_ENTRY_COMPLETION(self.pointer));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(TreeModel::wrap_pointer(ptr))
+            }
         }
     }
 

--- a/src/widgets/event_box.rs
+++ b/src/widgets/event_box.rs
@@ -12,6 +12,7 @@ struct_Widget!(EventBox);
 
 impl EventBox {
     pub fn new() -> Option<EventBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_event_box_new() };
         check_pointer!(tmp_pointer, EventBox)
     }

--- a/src/widgets/expander.rs
+++ b/src/widgets/expander.rs
@@ -17,6 +17,7 @@ struct_Widget!(Expander);
 
 impl Expander {
     pub fn new(label: &str) -> Option<Expander> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_expander_new(label.to_glib_none().0)
         };
@@ -24,6 +25,7 @@ impl Expander {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<Expander> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_expander_new_with_mnemonic(mnemonic.to_glib_none().0)
         };

--- a/src/widgets/file_chooser_dialog.rs
+++ b/src/widgets/file_chooser_dialog.rs
@@ -13,6 +13,7 @@ struct_Widget!(FileChooserDialog);
 impl FileChooserDialog {
     pub fn new<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                  action: ::FileChooserAction, buttons: T) -> FileChooserDialog {
+        assert_initialized_main_thread!();
         unsafe {
             let parent = match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),

--- a/src/widgets/file_chooser_widget.rs
+++ b/src/widgets/file_chooser_widget.rs
@@ -11,6 +11,7 @@ struct_Widget!(FileChooserWidget);
 
 impl FileChooserWidget {
     pub fn new(action: ::FileChooserAction) -> Option<FileChooserWidget> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_file_chooser_widget_new(action) };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/file_filter.rs
+++ b/src/widgets/file_filter.rs
@@ -11,6 +11,7 @@ pub struct FileFilter {
 
 impl FileFilter {
     pub fn new() -> Option<FileFilter> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_file_filter_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/file_filter.rs
+++ b/src/widgets/file_filter.rs
@@ -52,7 +52,7 @@ impl FileFilter {
         self.pointer
     }
 
-    pub fn wrap(pointer: *mut ffi::GtkFileFilter) -> Option<FileFilter> {
+    pub unsafe fn wrap(pointer: *mut ffi::GtkFileFilter) -> Option<FileFilter> {
         if pointer.is_null() {
             None
         } else {

--- a/src/widgets/fixed.rs
+++ b/src/widgets/fixed.rs
@@ -14,6 +14,7 @@ struct_Widget!(Fixed);
 
 impl Fixed {
     pub fn new() -> Option<Fixed> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_fixed_new() };
         check_pointer!(tmp_pointer, Fixed)
     }

--- a/src/widgets/flow_box.rs
+++ b/src/widgets/flow_box.rs
@@ -14,6 +14,7 @@ struct_Widget!(FlowBox);
 
 impl FlowBox {
     pub fn new() -> Option<FlowBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_revealer_new() };
         check_pointer!(tmp_pointer, FlowBox)
     }
@@ -173,6 +174,7 @@ struct_Widget!(FlowBoxChild);
 
 impl FlowBoxChild {
     pub fn new() -> Option<FlowBoxChild> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_flow_box_child_new() };
         check_pointer!(tmp_pointer, FlowBoxChild)
     }

--- a/src/widgets/font_button.rs
+++ b/src/widgets/font_button.rs
@@ -18,11 +18,13 @@ struct_Widget!(FontButton);
 
 impl FontButton {
     pub fn new() -> Option<FontButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_font_button_new() };
         check_pointer!(tmp_pointer, FontButton)
     }
 
     pub fn new_with_font(font_name: &str) -> Option<FontButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_font_button_new_with_font(font_name.to_glib_none().0)
         };

--- a/src/widgets/font_chooser_dialog.rs
+++ b/src/widgets/font_chooser_dialog.rs
@@ -11,6 +11,7 @@ struct_Widget!(FontChooserDialog);
 
 impl FontChooserDialog {
     pub fn new(title: &str, parent: Option<&::Window>) -> Option<FontChooserDialog> {
+        assert_initialized_main_thread!();
         let tmp = unsafe {
             ffi::gtk_font_chooser_dialog_new(title.to_glib_none().0,
                 match parent {

--- a/src/widgets/font_chooser_widget.rs
+++ b/src/widgets/font_chooser_widget.rs
@@ -11,6 +11,7 @@ struct_Widget!(FontChooserWidget);
 
 impl FontChooserWidget {
     pub fn new() -> Option<FontChooserWidget> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_color_chooser_widget_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/frame.rs
+++ b/src/widgets/frame.rs
@@ -12,6 +12,7 @@ struct_Widget!(Frame);
 
 impl Frame {
     pub fn new(label: Option<&str>) -> Option<Frame> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_frame_new(label.to_glib_none().0)
         };

--- a/src/widgets/gl_area.rs
+++ b/src/widgets/gl_area.rs
@@ -93,6 +93,7 @@ struct_Widget!(GLArea);
 impl GLArea {
     /// Creates a new GLArea widget.
     pub fn new() -> Option<GLArea> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_gl_area_new() };
         check_pointer!(tmp_pointer, GLArea)
     }

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -18,6 +18,7 @@ struct_Widget!(Grid);
 
 impl Grid {
     pub fn new() -> Option<Grid> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_grid_new() };
         check_pointer!(tmp_pointer, Grid)
     }

--- a/src/widgets/gtype.rs
+++ b/src/widgets/gtype.rs
@@ -13,34 +13,41 @@ pub mod g_type {
     use glib_ffi::{self};
 
     pub fn name(_type: glib_ffi::GType) -> Option<String> {
+        skip_assert_initialized!();
         unsafe {
             from_glib_none(ffi::g_type_name(_type))
         }
     }
 
     pub fn from_name(name: &str) -> glib_ffi::GType {
+        skip_assert_initialized!();
         unsafe {
             ffi::g_type_from_name(name.to_glib_none().0)
         }
     }
 
     pub fn parent(_type: glib_ffi::GType) -> glib_ffi::GType {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_parent(_type) }
     }
 
     pub fn depth(_type: glib_ffi::GType) -> u32 {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_depth(_type) }
     }
 
     pub fn next_base(leaf_type: glib_ffi::GType, root_type: glib_ffi::GType) -> glib_ffi::GType {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_next_base(leaf_type, root_type) }
     }
 
     pub fn is_a(_type: glib_ffi::GType, is_a_type: glib_ffi::GType) -> bool {
+        skip_assert_initialized!();
         unsafe { to_bool(ffi::g_type_is_a(_type, is_a_type)) }
     }
 
     pub fn children(_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
+        skip_assert_initialized!();
         let mut n_children = 0u32;
         let tmp_vec = unsafe { ffi::g_type_children(_type, &mut n_children) };
 
@@ -57,6 +64,7 @@ pub mod g_type {
     }
 
     pub fn interfaces(_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
+        skip_assert_initialized!();
         let mut n_interfaces = 0u32;
         let tmp_vec = unsafe { ffi::g_type_interfaces(_type, &mut n_interfaces) };
 
@@ -73,6 +81,7 @@ pub mod g_type {
     }
 
     pub fn interface_prerequisites(interface_type: glib_ffi::GType) -> Vec<glib_ffi::GType> {
+        skip_assert_initialized!();
         let mut n_prerequisites = 0u32;
         let tmp_vec = unsafe { ffi::g_type_interface_prerequisites(interface_type, &mut n_prerequisites) };
 
@@ -88,22 +97,27 @@ pub mod g_type {
     }
 
     pub fn interface_add_prerequisite(interface_type: glib_ffi::GType, prerequisite_type: glib_ffi::GType) {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_interface_add_prerequisite(interface_type, prerequisite_type) }
     }
 
     pub fn fundamental_next() -> glib_ffi::GType {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_fundamental_next() }
     }
 
     pub fn fundamental(type_id: glib_ffi::GType) -> glib_ffi::GType {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_fundamental(type_id) }
     }
 
     pub fn ensure(_type: glib_ffi::GType) {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_ensure(_type) }
     }
 
     pub fn get_type_registration_serial() -> u32 {
+        skip_assert_initialized!();
         unsafe { ffi::g_type_get_type_registration_serial() }
     }
 }

--- a/src/widgets/header_bar.rs
+++ b/src/widgets/header_bar.rs
@@ -16,6 +16,7 @@ struct_Widget!(HeaderBar);
 
 impl HeaderBar {
     pub fn new() -> Option<HeaderBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_header_bar_new() };
         check_pointer!(tmp_pointer, HeaderBar)
     }

--- a/src/widgets/icon_view.rs
+++ b/src/widgets/icon_view.rs
@@ -31,13 +31,13 @@ impl IconView {
     }
 
     pub fn get_model(&self) -> Option<TreeModel> {
-        let tmp_pointer = unsafe { ffi::gtk_icon_view_get_model(GTK_ICON_VIEW(self.pointer)) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { ::gobject_ffi::g_object_ref(tmp_pointer as *mut _) };
-            Some(TreeModel::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_icon_view_get_model(GTK_ICON_VIEW(self.pointer));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(TreeModel::wrap_pointer(ptr))
+            }
         }
     }
 
@@ -66,12 +66,13 @@ impl IconView {
     }
 
     pub fn get_path_at_pos(&self, x: i32, y: i32) -> Option<TreePath> {
-        let tmp_pointer = unsafe { ffi::gtk_icon_view_get_path_at_pos(GTK_ICON_VIEW(self.pointer), x, y) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(TreePath::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_icon_view_get_path_at_pos(GTK_ICON_VIEW(self.pointer), x, y);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(TreePath::wrap_pointer(ptr))
+            }
         }
     }
 

--- a/src/widgets/icon_view.rs
+++ b/src/widgets/icon_view.rs
@@ -12,16 +12,19 @@ struct_Widget!(IconView);
 
 impl IconView {
     pub fn new() -> Option<IconView> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_icon_view_new() };
         check_pointer!(tmp_pointer, IconView)
     }
 
     /*pub fn new_with_area(area: &::CellArea) -> Option<IconView> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_icon_view_new_with_area(::FFIWidget::unwrap(area)) };
         check_pointer!(tmp_pointer, IconView)
     }*/
 
     pub fn new_with_model(model: &TreeModel) -> Option<IconView> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_icon_view_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, IconView)
     }

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -15,6 +15,7 @@ struct_Widget!(Image);
 
 impl Image {
     pub fn new() -> Option<Image> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_image_new()
         };
@@ -22,6 +23,7 @@ impl Image {
     }
 
     pub fn new_from_file(filename: &str) -> Option<Image> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_image_new_from_file(filename.to_glib_none().0)
         };
@@ -29,6 +31,7 @@ impl Image {
     }
 
     pub fn new_from_pixbuf(pixbuf: &Pixbuf) -> Option<Image> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_image_new_from_pixbuf(pixbuf.to_glib_none().0)
         };
@@ -36,6 +39,7 @@ impl Image {
     }
 
     pub fn new_from_icon_name(icon_name: &str, size: i32) -> Option<Image> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_image_new_from_icon_name(icon_name.to_glib_none().0, size)
         };

--- a/src/widgets/info_bar.rs
+++ b/src/widgets/info_bar.rs
@@ -20,6 +20,7 @@ struct_Widget!(InfoBar);
 
 impl InfoBar {
     pub fn new() -> Option<InfoBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_info_bar_new() };
         check_pointer!(tmp_pointer, InfoBar)
     }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -20,6 +20,7 @@ struct_Widget!(Label);
 
 impl Label {
     pub fn new(text: &str) -> Option<Label> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_label_new(text.to_glib_none().0)
         };
@@ -27,6 +28,7 @@ impl Label {
     }
 
     pub fn new_with_mnemonic(text: &str) -> Option<Label> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_label_new_with_mnemonic(text.to_glib_none().0)
         };

--- a/src/widgets/layout.rs
+++ b/src/widgets/layout.rs
@@ -12,6 +12,7 @@ struct_Widget!(Layout);
 
 impl Layout {
     pub fn new(hadjustment: &::Adjustment, vadjustment: &::Adjustment) -> Option<Layout> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe {
             ffi::gtk_layout_new(hadjustment.unwrap_pointer(),
                                 vadjustment.unwrap_pointer())

--- a/src/widgets/level_bar.rs
+++ b/src/widgets/level_bar.rs
@@ -23,11 +23,13 @@ struct_Widget!(LevelBar);
 
 impl LevelBar {
     pub fn new() -> Option<LevelBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_level_bar_new() };
         check_pointer!(tmp_pointer, LevelBar)
     }
 
     pub fn new_for_interval(min: f64, max: f64) -> Option<LevelBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_level_bar_new_for_interval(min as c_double, max as c_double) };
         check_pointer!(tmp_pointer, LevelBar)
     }

--- a/src/widgets/link_button.rs
+++ b/src/widgets/link_button.rs
@@ -18,6 +18,7 @@ struct_Widget!(LinkButton);
 
 impl LinkButton {
     pub fn new(uri: &str) -> Option<LinkButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_link_button_new(uri.to_glib_none().0)
         };
@@ -25,6 +26,7 @@ impl LinkButton {
     }
 
     pub fn new_with_label(uri: &str, label: &str) -> Option<LinkButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_link_button_new_with_label(uri.to_glib_none().0, label.to_glib_none().0)
         };

--- a/src/widgets/list_box.rs
+++ b/src/widgets/list_box.rs
@@ -88,13 +88,13 @@ impl ListBox {
     }
 
     pub fn get_adjustment(&self) -> Option<::Adjustment> {
-        let tmp_pointer = unsafe {
-            ffi::gtk_list_box_get_adjustment(GTK_LIST_BOX(self.pointer))
-        };
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(::Adjustment::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_list_box_get_adjustment(GTK_LIST_BOX(self.pointer));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(::Adjustment::wrap_pointer(ptr))
+            }
         }
     }
 

--- a/src/widgets/list_box.rs
+++ b/src/widgets/list_box.rs
@@ -14,6 +14,7 @@ struct_Widget!(ListBox);
 
 impl ListBox {
     pub fn new() -> Option<ListBox> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_list_box_new() };
         check_pointer!(tmp_pointer, ListBox)
     }
@@ -156,6 +157,7 @@ struct_Widget!(ListBoxRow);
 
 impl ListBoxRow {
     pub fn new() -> Option<ListBoxRow> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_list_box_row_new() };
         check_pointer!(tmp_pointer, ListBoxRow)
     }

--- a/src/widgets/list_store.rs
+++ b/src/widgets/list_store.rs
@@ -17,6 +17,7 @@ pub struct ListStore {
 
 impl ListStore {
     pub fn new(column_types: &[Type]) -> Option<ListStore> {
+        assert_initialized_main_thread!();
         let column_types_ffi: Vec<GType> = column_types.iter().map(|n| n.to_glib()).collect();
         let tmp_pointer = unsafe { ffi::gtk_list_store_newv(column_types.len() as i32, column_types_ffi.as_ptr() as *mut GType) };
         check_pointer!(tmp_pointer, ListStore, G_OBJECT_FROM_LIST_STORE)

--- a/src/widgets/list_store.rs
+++ b/src/widgets/list_store.rs
@@ -141,10 +141,10 @@ impl ListStore {
         if self.pointer.is_null() {
             None
         } else {
-            let tmp = ::cast::GTK_TREE_MODEL_FROM_LIST_STORE(self.pointer);
-
-            unsafe { ::gobject_ffi::g_object_ref(tmp as *mut _) };
-            Some(::TreeModel::wrap_pointer(tmp))
+            unsafe {
+                let tmp = ::cast::GTK_TREE_MODEL_FROM_LIST_STORE(self.pointer);
+                Some(::TreeModel::wrap_pointer(tmp))
+            }
         }
     }
 
@@ -161,7 +161,7 @@ impl ListStore {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_liststore: *mut ffi::GtkListStore) -> ListStore {
+    pub unsafe fn wrap_pointer(c_liststore: *mut ffi::GtkListStore) -> ListStore {
         ListStore {
             pointer: c_liststore
         }

--- a/src/widgets/lock_button.rs
+++ b/src/widgets/lock_button.rs
@@ -14,6 +14,7 @@ struct_Widget!(LockButton);
 
 impl LockButton {
     pub fn new(permission: &Permission) -> Option<LockButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_lock_button_new(permission.unwrap()) };
         check_pointer!(tmp_pointer, LockButton)
     }

--- a/src/widgets/menu.rs
+++ b/src/widgets/menu.rs
@@ -15,6 +15,7 @@ impl_TraitWidget!(Menu);
 
 impl Menu {
     pub fn new() -> Option<Menu> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_menu_new() };
         check_pointer!(tmp_pointer, Menu)
     }

--- a/src/widgets/menu_button.rs
+++ b/src/widgets/menu_button.rs
@@ -13,6 +13,7 @@ struct_Widget!(MenuButton);
 
 impl MenuButton {
     pub fn new() -> Option<MenuButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_menu_button_new() };
         check_pointer!(tmp_pointer, MenuButton)
     }

--- a/src/widgets/menu_item.rs
+++ b/src/widgets/menu_item.rs
@@ -12,11 +12,13 @@ struct_Widget!(MenuItem);
 
 impl MenuItem {
     pub fn new() -> Option<MenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_menu_item_new() };
         check_pointer!(tmp_pointer, MenuItem)
     }
 
     pub fn new_with_label(label: &str) -> Option<MenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_menu_item_new_with_label(label.to_glib_none().0)
         };
@@ -24,6 +26,7 @@ impl MenuItem {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<MenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_menu_item_new_with_mnemonic(mnemonic.to_glib_none().0)
         };

--- a/src/widgets/menu_tool_button.rs
+++ b/src/widgets/menu_tool_button.rs
@@ -15,6 +15,7 @@ struct_Widget!(MenuToolButton);
 
 impl MenuToolButton {
     pub fn new<T: ::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<MenuToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             let icon_widget_ptr = match icon_widget {
                 Some(i) => i.unwrap_widget(),
@@ -27,6 +28,7 @@ impl MenuToolButton {
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<MenuToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_menu_tool_button_new_from_stock(stock_id.to_glib_none().0)
         };

--- a/src/widgets/message_dialog.rs
+++ b/src/widgets/message_dialog.rs
@@ -11,6 +11,7 @@ struct_Widget!(MessageDialog);
 
 impl MessageDialog {
     pub fn new(parent: Option<&::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType) -> Option<MessageDialog> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_message_dialog_new(match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
@@ -25,6 +26,7 @@ impl MessageDialog {
     }
 
     pub fn new_with_markup(parent: Option<&::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType, markup: &str) -> Option<MessageDialog> {
+        assert_initialized_main_thread!();
         //gtk_message_dialog_new_with_markup
         match MessageDialog::new(parent, flags, _type, buttons) {
             Some(m) => {

--- a/src/widgets/note_book.rs
+++ b/src/widgets/note_book.rs
@@ -15,6 +15,7 @@ struct_Widget!(NoteBook);
 
 impl NoteBook {
     pub fn new() -> Option<NoteBook> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_notebook_new() };
         check_pointer!(tmp_pointer, NoteBook)
     }

--- a/src/widgets/overlay.rs
+++ b/src/widgets/overlay.rs
@@ -12,6 +12,7 @@ struct_Widget!(Overlay);
 
 impl Overlay {
     pub fn new() -> Option<Overlay> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_overlay_new() };
         check_pointer!(tmp_pointer, Overlay)
     }

--- a/src/widgets/page_setup.rs
+++ b/src/widgets/page_setup.rs
@@ -12,6 +12,7 @@ pub struct PageSetup {
 
 impl PageSetup {
     pub fn new() -> Option<PageSetup> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_page_setup_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/page_setup_unix_dialog.rs
+++ b/src/widgets/page_setup_unix_dialog.rs
@@ -11,6 +11,7 @@ struct_Widget!(PageSetupUnixDialog);
 
 impl PageSetupUnixDialog {
     pub fn new(title: &str, parent: Option<&::Window>) -> Option<PageSetupUnixDialog> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             title.with_c_str(|c_str|{
                 ffi::gtk_page_setup_unix_dialog_new(match parent {

--- a/src/widgets/paned.rs
+++ b/src/widgets/paned.rs
@@ -25,6 +25,7 @@ struct_Widget!(Paned);
 
 impl Paned {
     pub fn new(orientation: Orientation) -> Option<Paned> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_paned_new(orientation) };
         check_pointer!(tmp_pointer, Paned)
     }

--- a/src/widgets/paper_size.rs
+++ b/src/widgets/paper_size.rs
@@ -14,6 +14,7 @@ struct_Widget!(PaperSize);
 
 impl PaperSize {
     pub fn new(name: &str) -> Option<PaperSize> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_paper_size_new(name.to_glib_none().0)
         };
@@ -26,6 +27,7 @@ impl PaperSize {
     }
 
     pub fn new_from_ppd(ppd_name: &str, ppd_display_name: &str, width: f64, height: f64) -> Option<PaperSize> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_paper_size_new_from_ppd(ppd_name.to_glib_none().0,
                                              ppd_display_name.to_glib_none().0,
@@ -40,6 +42,7 @@ impl PaperSize {
     }
 
     pub fn new_custom(name: &str, display_name: &str, width: f64, height: f64, unit: ::Unit) -> Option<PaperSize> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_paper_size_new_custom(name.to_glib_none().0,
                                            display_name.to_glib_none().0,
@@ -68,6 +71,7 @@ impl PaperSize {
     }
 
     pub fn get_paper_sizes(include_custom: bool) -> glib::List<Box<PaperSize>> {
+        assert_initialized_main_thread!();
         let tmp = unsafe { ffi::gtk_paper_size_get_paper_sizes(to_gboolean(include_custom))
         };
 
@@ -138,6 +142,7 @@ impl PaperSize {
     }
 
     pub fn get_default() -> Option<String> {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_none(
                 ffi::gtk_paper_size_get_default())

--- a/src/widgets/places_sidebar.rs
+++ b/src/widgets/places_sidebar.rs
@@ -13,6 +13,7 @@ struct_Widget!(PlacesSidebar);
 
 impl PlacesSidebar {
     pub fn new() -> Option<PlacesSidebar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_places_sidebar_new() };
         check_pointer!(tmp_pointer, PlacesSidebar)
     }

--- a/src/widgets/popover.rs
+++ b/src/widgets/popover.rs
@@ -13,6 +13,7 @@ struct_Widget!(Popover);
 
 impl Popover {
     pub fn new<T: ::WidgetTrait>(relative_to: &T) -> Option<Popover> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_popover_new(relative_to.unwrap_widget()) };
         check_pointer!(tmp_pointer, Popover)
     }

--- a/src/widgets/popover_menu.rs
+++ b/src/widgets/popover_menu.rs
@@ -13,6 +13,7 @@ struct_Widget!(PopoverMenu);
 
 impl PopoverMenu {
     pub fn new() -> Option<PopoverMenu> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_popover_menu_new() };
         check_pointer!(tmp_pointer, PopoverMenu)
     }

--- a/src/widgets/print_settings.rs
+++ b/src/widgets/print_settings.rs
@@ -12,6 +12,7 @@ struct_Widget!(PrintSettings);
 
 impl PrintSettings {
     pub fn new() -> Option<PrintSettings> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_print_settings_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -16,6 +16,7 @@ struct_Widget!(ProgressBar);
 
 impl ProgressBar {
     pub fn new() -> Option<ProgressBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_progress_bar_new() };
         check_pointer!(tmp_pointer, ProgressBar)
     }

--- a/src/widgets/radio_button.rs
+++ b/src/widgets/radio_button.rs
@@ -15,11 +15,13 @@ struct_Widget!(RadioButton);
 
 impl RadioButton {
     pub fn new() -> Option<RadioButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_radio_button_new(ptr::null_mut()) };
         check_pointer!(tmp_pointer, RadioButton)
     }
 
     pub fn new_with_label(label: &str) -> Option<RadioButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_radio_button_new_with_label(ptr::null_mut(),
                                                  label.to_glib_none().0)
@@ -28,6 +30,7 @@ impl RadioButton {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<RadioButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_radio_button_new_with_mnemonic(ptr::null_mut(),
                                                     mnemonic.to_glib_none().0)

--- a/src/widgets/recent_chooser_dialog.rs
+++ b/src/widgets/recent_chooser_dialog.rs
@@ -14,6 +14,7 @@ struct_Widget!(RecentChooserDialog);
 impl RecentChooserDialog {
     pub fn new<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                  buttons: T) -> RecentChooserDialog {
+        assert_initialized_main_thread!();
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
             None => ptr::null_mut()
@@ -30,6 +31,7 @@ impl RecentChooserDialog {
 
     pub fn new_for_manager<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                              manager: &::RecentManager, buttons: T) -> RecentChooserDialog {
+        skip_assert_initialized!();
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
             None => ptr::null_mut()

--- a/src/widgets/recent_chooser_widget.rs
+++ b/src/widgets/recent_chooser_widget.rs
@@ -13,11 +13,13 @@ struct_Widget!(RecentChooserWidget);
 
 impl RecentChooserWidget {
     pub fn new() -> Option<RecentChooserWidget> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_recent_chooser_widget_new() };
         check_pointer!(tmp_pointer, RecentChooserWidget)
     }
 
     pub fn new_for_manager(manager: &RecentManager) -> Option<RecentChooserWidget> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_recent_chooser_widget_new_for_manager(GTK_RECENT_MANAGER(manager.unwrap_widget())) };
         check_pointer!(tmp_pointer, RecentChooserWidget)
     }

--- a/src/widgets/recent_filter.rs
+++ b/src/widgets/recent_filter.rs
@@ -45,7 +45,7 @@ impl RecentFilter {
         unsafe { to_bool(ffi::gtk_recent_filter_filter(self.pointer, &filter_info.get_ffi())) }
     }
 
-    pub fn wrap(pointer: *mut ffi::GtkRecentFilter) -> Option<RecentFilter> {
+    pub unsafe fn wrap(pointer: *mut ffi::GtkRecentFilter) -> Option<RecentFilter> {
         if pointer.is_null() {
             None
         } else {

--- a/src/widgets/recent_filter.rs
+++ b/src/widgets/recent_filter.rs
@@ -12,6 +12,7 @@ pub struct RecentFilter {
 
 impl RecentFilter {
     pub fn new() -> Option<RecentFilter> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_recent_filter_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/recent_filter_info.rs
+++ b/src/widgets/recent_filter_info.rs
@@ -18,7 +18,7 @@ pub struct RecentFilterInfo {
 
 impl RecentFilterInfo {
     #[doc(hidden)]
-    pub fn from_c(ptr: *mut ffi::GtkRecentFilterInfo) -> RecentFilterInfo {
+    pub unsafe fn from_c(ptr: *mut ffi::GtkRecentFilterInfo) -> RecentFilterInfo {
         if ptr.is_null() {
             Default::default()
         } else {
@@ -26,35 +26,33 @@ impl RecentFilterInfo {
             let mut tmp_groups = Vec::new();
             let mut count = 0;
 
-            unsafe {
-                loop {
-                    let tmp = (*ptr).applications.offset(count);
+            loop {
+                let tmp = (*ptr).applications.offset(count);
 
-                    if tmp.is_null() {
-                        break;
-                    }
-                    count = count + 1;
-                    tmp_app.push(String::from_utf8_lossy(::std::ffi::CStr::from_ptr(*tmp).to_bytes()).to_string());
+                if tmp.is_null() {
+                    break;
                 }
-                count = 0;
-                loop {
-                    let tmp = (*ptr).groups.offset(count);
+                count = count + 1;
+                tmp_app.push(String::from_utf8_lossy(::std::ffi::CStr::from_ptr(*tmp).to_bytes()).to_string());
+            }
+            count = 0;
+            loop {
+                let tmp = (*ptr).groups.offset(count);
 
-                    if tmp.is_null() {
-                        break;
-                    }
-                    count = count + 1;
-                    tmp_groups.push(String::from_utf8_lossy(::std::ffi::CStr::from_ptr(*tmp).to_bytes()).to_string());
+                if tmp.is_null() {
+                    break;
                 }
-                RecentFilterInfo {
-                    contains: (*ptr).contains,
-                    uri: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).uri).to_bytes()).to_string(),
-                    display_name: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).display_name).to_bytes()).to_string(),
-                    mime_type: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).mime_type).to_bytes()).to_string(),
-                    applications: tmp_app,
-                    groups: tmp_groups,
-                    age: (*ptr).age
-                }
+                count = count + 1;
+                tmp_groups.push(String::from_utf8_lossy(::std::ffi::CStr::from_ptr(*tmp).to_bytes()).to_string());
+            }
+            RecentFilterInfo {
+                contains: (*ptr).contains,
+                uri: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).uri).to_bytes()).to_string(),
+                display_name: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).display_name).to_bytes()).to_string(),
+                mime_type: String::from_utf8_lossy(::std::ffi::CStr::from_ptr((*ptr).mime_type).to_bytes()).to_string(),
+                applications: tmp_app,
+                groups: tmp_groups,
+                age: (*ptr).age
             }
         }
     }

--- a/src/widgets/recent_filter_info.rs
+++ b/src/widgets/recent_filter_info.rs
@@ -90,6 +90,7 @@ impl RecentFilterInfo {
 
 impl Default for RecentFilterInfo {
     fn default() -> RecentFilterInfo {
+        skip_assert_initialized!();
         RecentFilterInfo {
             contains: ::RecentFilterFlags::empty(),
             uri: String::new(),

--- a/src/widgets/recent_manager.rs
+++ b/src/widgets/recent_manager.rs
@@ -13,6 +13,7 @@ struct_Widget!(RecentManager);
 
 impl RecentManager {
     pub fn new() -> Option<RecentManager> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_recent_manager_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/revealer.rs
+++ b/src/widgets/revealer.rs
@@ -13,6 +13,7 @@ struct_Widget!(Revealer);
 
 impl Revealer {
     pub fn new() -> Option<Revealer> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_revealer_new() };
         check_pointer!(tmp_pointer, Revealer)
     }

--- a/src/widgets/scale.rs
+++ b/src/widgets/scale.rs
@@ -22,6 +22,7 @@ struct_Widget!(Scale);
 impl Scale {
     pub fn new(orientation: Orientation,
                adjustment: &::Adjustment) -> Option<Scale> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_scale_new(orientation, adjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Scale)
     }
@@ -30,6 +31,7 @@ impl Scale {
                           min: f64,
                           max: f64,
                           step: f64) -> Option<Scale> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_scale_new_with_range(orientation, min as c_double, max as c_double, step as c_double) };
         check_pointer!(tmp_pointer, Scale)
     }

--- a/src/widgets/scale_button.rs
+++ b/src/widgets/scale_button.rs
@@ -21,6 +21,7 @@ struct_Widget!(ScaleButton);
 impl ScaleButton {
     // FIXME: icons -> last parameter
     pub fn new(size: i32, min: f64, max: f64, step: f64) -> Option<ScaleButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_scale_button_new(size, min as c_double, max as c_double, step as c_double, ptr::null_mut()) };
         check_pointer!(tmp_pointer, ScaleButton)
     }

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -11,6 +11,7 @@ struct_Widget!(ScrollBar);
 
 impl ScrollBar {
     pub fn new(orientation: ::Orientation, adjustment: &::Adjustment) -> Option<ScrollBar> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_scrollbar_new(orientation, adjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, ScrollBar)
     }

--- a/src/widgets/scrolled_window.rs
+++ b/src/widgets/scrolled_window.rs
@@ -12,7 +12,7 @@ struct_Widget!(ScrolledWindow);
 
 impl ScrolledWindow {
     pub fn new(h_adjustment: Option<::Adjustment>, v_adjustment: Option<::Adjustment>) -> Option<ScrolledWindow> {
-
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_scrolled_window_new(
                 h_adjustment.map_or(ptr::null_mut(), |p| { p.unwrap_pointer() }),

--- a/src/widgets/search_bar.rs
+++ b/src/widgets/search_bar.rs
@@ -14,6 +14,7 @@ struct_Widget!(SearchBar);
 
 impl SearchBar {
     pub fn new() -> Option<SearchBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_search_bar_new() };
         check_pointer!(tmp_pointer, SearchBar)
     }

--- a/src/widgets/search_entry.rs
+++ b/src/widgets/search_entry.rs
@@ -15,6 +15,7 @@ struct_Widget!(SearchEntry);
 
 impl SearchEntry {
     pub fn new() -> Option<SearchEntry> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_search_entry_new() };
         check_pointer!(tmp_pointer, SearchEntry)
     }

--- a/src/widgets/separator.rs
+++ b/src/widgets/separator.rs
@@ -12,6 +12,7 @@ struct_Widget!(Separator);
 
 impl Separator {
     pub fn new(orientation: Orientation) -> Option<Separator> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_separator_new(orientation) };
         check_pointer!(tmp_pointer, Separator)
     }

--- a/src/widgets/separator_menu_item.rs
+++ b/src/widgets/separator_menu_item.rs
@@ -11,6 +11,7 @@ struct_Widget!(SeparatorMenuItem);
 
 impl SeparatorMenuItem {
     pub fn new() -> Option<SeparatorMenuItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_separator_menu_item_new() };
         check_pointer!(tmp_pointer, SeparatorMenuItem)
     }

--- a/src/widgets/separator_tool_item.rs
+++ b/src/widgets/separator_tool_item.rs
@@ -13,6 +13,7 @@ struct_Widget!(SeparatorToolItem);
 
 impl SeparatorToolItem {
     pub fn new() -> Option<SeparatorToolItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_separator_tool_item_new() };
         check_pointer!(tmp_pointer, SeparatorToolItem)
     }

--- a/src/widgets/size_group.rs
+++ b/src/widgets/size_group.rs
@@ -13,6 +13,7 @@ pub struct SizeGroup {
 
 impl SizeGroup {
     pub fn new(mode: ::SizeGroupMode) -> Option<SizeGroup> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_size_group_new(mode) };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/socket.rs
+++ b/src/widgets/socket.rs
@@ -12,6 +12,7 @@ struct_Widget!(Socket);
 
 impl Socket {
     pub fn new() -> Option<Socket> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_socket_new() };
 
         check_pointer!(tmp_pointer, Socket)

--- a/src/widgets/spin_button.rs
+++ b/src/widgets/spin_button.rs
@@ -27,11 +27,13 @@ impl SpinButton {
     pub fn new(adjustment: &::Adjustment,
                climb_rate: f64,
                digits: u32) -> Option<SpinButton> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_spin_button_new(adjustment.unwrap_pointer(), climb_rate as c_double, digits as c_uint) };
         check_pointer!(tmp_pointer, SpinButton)
     }
 
     pub fn new_with_range(min: f64, max: f64, step: f64) -> Option<SpinButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_spin_button_new_with_range(min as c_double, max as c_double, step as c_double) };
         check_pointer!(tmp_pointer, SpinButton)
     }

--- a/src/widgets/spinner.rs
+++ b/src/widgets/spinner.rs
@@ -12,6 +12,7 @@ struct_Widget!(Spinner);
 
 impl Spinner {
     pub fn new() -> Option<Spinner> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_spinner_new() };
         check_pointer!(tmp_pointer, Spinner)
     }

--- a/src/widgets/stack.rs
+++ b/src/widgets/stack.rs
@@ -16,6 +16,7 @@ struct_Widget!(Stack);
 
 impl Stack {
     pub fn new() -> Option<Stack> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_stack_new() };
         check_pointer!(tmp_pointer, Stack)
     }

--- a/src/widgets/stack_sidebar.rs
+++ b/src/widgets/stack_sidebar.rs
@@ -14,6 +14,7 @@ struct_Widget!(StackSidebar);
 
 impl StackSidebar {
     pub fn new() -> Option<StackSidebar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_stack_sidebar_new() };
         check_pointer!(tmp_pointer, StackSidebar)
     }

--- a/src/widgets/stack_switcher.rs
+++ b/src/widgets/stack_switcher.rs
@@ -13,6 +13,7 @@ struct_Widget!(StackSwitcher);
 
 impl StackSwitcher {
     pub fn new() -> Option<StackSwitcher> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_stack_switcher_new() };
         check_pointer!(tmp_pointer, StackSwitcher)
     }

--- a/src/widgets/status_bar.rs
+++ b/src/widgets/status_bar.rs
@@ -14,6 +14,7 @@ struct_Widget!(StatusBar);
 
 impl StatusBar {
     pub fn new() -> Option<StatusBar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_statusbar_new() };
 
         check_pointer!(tmp_pointer, StatusBar)

--- a/src/widgets/status_icon.rs
+++ b/src/widgets/status_icon.rs
@@ -22,30 +22,35 @@ glib_wrapper! {
 
 impl StatusIcon {
     pub fn new() -> StatusIcon {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_full(ffi::gtk_status_icon_new())
         }
     }
 
     pub fn new_from_file(filename: &str) -> StatusIcon {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_full(ffi::gtk_status_icon_new_from_file(filename.to_glib_none().0))
         }
     }
 
     pub fn new_from_icon_name(icon_name: &str) -> StatusIcon {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_full(ffi::gtk_status_icon_new_from_icon_name(icon_name.to_glib_none().0))
         }
     }
 
     pub fn new_from_pixbuf(pixbuf: &gdk::pixbuf::Pixbuf) -> StatusIcon {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_full(ffi::gtk_status_icon_new_from_pixbuf(pixbuf.to_glib_none().0))
         }
     }
 
     pub fn new_from_stock(stock_id: &str) -> StatusIcon {
+        assert_initialized_main_thread!();
         unsafe {
             from_glib_full(ffi::gtk_status_icon_new_from_stock(stock_id.to_glib_none().0))
         }

--- a/src/widgets/style_context.rs
+++ b/src/widgets/style_context.rs
@@ -14,6 +14,7 @@ pub struct StyleContext {
 
 impl StyleContext {
     pub fn new() -> Self {
+        assert_initialized_main_thread!();
         unsafe { StyleContext { pointer: ffi::gtk_style_context_new() } }
     }
 
@@ -28,6 +29,7 @@ impl StyleContext {
 
     pub fn add_provider_for_screen<T: ::StyleProviderTrait>(screen: &gdk::Screen, provider: &T,
                                                             priority: u32) {
+        assert_initialized_main_thread!();
         unsafe {
             ffi::gtk_style_context_add_provider_for_screen(
                 screen.to_glib_none().0,

--- a/src/widgets/switch.rs
+++ b/src/widgets/switch.rs
@@ -17,6 +17,7 @@ struct_Widget!(Switch);
 
 impl Switch {
     pub fn new() -> Option<Switch> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_switch_new() };
         check_pointer!(tmp_pointer, Switch)
     }

--- a/src/widgets/text_attributes.rs
+++ b/src/widgets/text_attributes.rs
@@ -12,6 +12,7 @@ pub struct TextAttributes {
 
 impl TextAttributes {
     pub fn new() -> Option<TextAttributes> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_text_attributes_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/text_buffer.rs
+++ b/src/widgets/text_buffer.rs
@@ -16,6 +16,7 @@ struct_Widget!(TextBuffer);
 
 impl TextBuffer {
     pub fn new(text_tag_table: Option<::TextTagTable>) -> Option<TextBuffer> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             match text_tag_table {
                 Some(ttl) => ffi::gtk_text_buffer_new(ttl.unwrap_pointer()),

--- a/src/widgets/text_child_anchor.rs
+++ b/src/widgets/text_child_anchor.rs
@@ -11,6 +11,7 @@ pub struct TextChildAnchor {
 
 impl TextChildAnchor {
     pub fn new() -> Option<TextChildAnchor> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_text_child_anchor_new() };
 
         if tmp_pointer.is_null() {

--- a/src/widgets/text_mark.rs
+++ b/src/widgets/text_mark.rs
@@ -14,6 +14,7 @@ pub struct TextMark {
 
 impl TextMark {
     pub fn new(name: &str, left_gravity: bool) -> Option<TextMark> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_text_mark_new(name.to_glib_none().0, to_gboolean(left_gravity))
         };

--- a/src/widgets/text_tag.rs
+++ b/src/widgets/text_tag.rs
@@ -13,6 +13,7 @@ pub struct TextTag {
 
 impl TextTag {
     pub fn new(name: &str) -> Option<TextTag> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_text_tag_new(name.to_glib_none().0)
         };

--- a/src/widgets/text_tag_table.rs
+++ b/src/widgets/text_tag_table.rs
@@ -12,6 +12,7 @@ pub struct TextTagTable {
 
 impl TextTagTable {
     pub fn new() -> Option<TextTagTable> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_text_tag_table_new() };
         if tmp_pointer.is_null() {
             None

--- a/src/widgets/text_view.rs
+++ b/src/widgets/text_view.rs
@@ -16,11 +16,13 @@ struct_Widget!(TextView);
 
 impl TextView {
     pub fn new() -> Option<TextView> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_text_view_new() };
         check_pointer!(tmp_pointer, TextView)
     }
 
     pub fn new_with_buffer(buffer: TextBuffer) -> Option<TextView> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe {
             ffi::gtk_text_view_new_with_buffer(GTK_TEXT_BUFFER(buffer.unwrap_widget()))
         };

--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -16,11 +16,13 @@ struct_Widget!(ToggleButton);
 
 impl ToggleButton {
     pub fn new() -> Option<ToggleButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_toggle_button_new() };
         check_pointer!(tmp_pointer, ToggleButton)
     }
 
     pub fn new_with_label(label: &str) -> Option<ToggleButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_toggle_button_new_with_label(label.to_glib_none().0)
         };
@@ -28,6 +30,7 @@ impl ToggleButton {
     }
 
     pub fn new_with_mnemonic(mnemonic: &str) -> Option<ToggleButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_toggle_button_new_with_mnemonic(mnemonic.to_glib_none().0)
         };

--- a/src/widgets/toggle_tool_button.rs
+++ b/src/widgets/toggle_tool_button.rs
@@ -12,11 +12,13 @@ struct_Widget!(ToggleToolButton);
 
 impl ToggleToolButton {
     pub fn new() -> Option<ToggleToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new() };
         check_pointer!(tmp_pointer, ToggleToolButton)
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToggleToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_toggle_tool_button_new_from_stock(stock_id.to_glib_none().0) };
         check_pointer!(tmp_pointer, ToggleToolButton)
     }

--- a/src/widgets/tool_bar.rs
+++ b/src/widgets/tool_bar.rs
@@ -23,6 +23,7 @@ struct_Widget!(Toolbar);
 
 impl Toolbar {
     pub fn new() -> Option<Toolbar> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_toolbar_new() };
         check_pointer!(tmp_pointer, Toolbar)
     }

--- a/src/widgets/tool_button.rs
+++ b/src/widgets/tool_button.rs
@@ -14,6 +14,7 @@ struct_Widget!(ToolButton);
 
 impl ToolButton {
     pub fn new<T: ::WidgetTrait>(icon_widget: Option<&T>, label: Option<&str>) -> Option<ToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             let icon_widget_ptr = match icon_widget {
                 Some(i) => i.unwrap_widget(),
@@ -25,6 +26,7 @@ impl ToolButton {
     }
 
     pub fn new_from_stock(stock_id: &str) -> Option<ToolButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_tool_button_new_from_stock(stock_id.to_glib_none().0)
         };

--- a/src/widgets/tool_item.rs
+++ b/src/widgets/tool_item.rs
@@ -11,6 +11,7 @@ struct_Widget!(ToolItem);
 
 impl ToolItem {
     pub fn new() -> Option<ToolItem> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_tool_item_new() };
         check_pointer!(tmp_pointer, ToolItem)
     }

--- a/src/widgets/tool_item_group.rs
+++ b/src/widgets/tool_item_group.rs
@@ -15,6 +15,7 @@ struct_Widget!(ToolItemGroup);
 
 impl ToolItemGroup {
     pub fn new(label: &str) -> Option<ToolItemGroup> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe {
             ffi::gtk_tool_item_group_new(label.to_glib_none().0)
         };

--- a/src/widgets/tool_palette.rs
+++ b/src/widgets/tool_palette.rs
@@ -14,6 +14,7 @@ struct_Widget!(ToolPalette);
 
 impl ToolPalette {
     pub fn new() -> Option<ToolPalette> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_tool_palette_new() };
         check_pointer!(tmp_pointer, ToolPalette)
     }

--- a/src/widgets/tree_model.rs
+++ b/src/widgets/tree_model.rs
@@ -56,14 +56,13 @@ impl TreeModel {
      }
 
     pub fn get_path(&self, iter: &TreeIter) -> Option<TreePath> {
-        let tmp_pointer = unsafe {
-            ffi::gtk_tree_model_get_path(self.pointer, iter.to_glib_none().0 as *mut _)
-        };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(TreePath::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_tree_model_get_path(self.pointer, iter.to_glib_none().0 as *mut _);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(TreePath::wrap_pointer(ptr))
+            }
         }
     }
 
@@ -162,10 +161,8 @@ impl TreeModel {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_treemodel: *mut ffi::GtkTreeModel) -> TreeModel {
-        unsafe {
-            ::gobject_ffi::g_object_ref(c_treemodel as *mut _);
-        }
+    pub unsafe fn wrap_pointer(c_treemodel: *mut ffi::GtkTreeModel) -> TreeModel {
+        ::gobject_ffi::g_object_ref(c_treemodel as *mut _);
         TreeModel {
             pointer: c_treemodel
         }

--- a/src/widgets/tree_path.rs
+++ b/src/widgets/tree_path.rs
@@ -151,7 +151,7 @@ impl TreePath {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_treepath: *mut ffi::GtkTreePath) -> TreePath {
+    pub unsafe fn wrap_pointer(c_treepath: *mut ffi::GtkTreePath) -> TreePath {
         TreePath {
             pointer: c_treepath
         }

--- a/src/widgets/tree_path.rs
+++ b/src/widgets/tree_path.rs
@@ -12,6 +12,7 @@ pub struct TreePath {
 
 impl TreePath {
     pub fn new() -> Option<TreePath> {
+        assert_initialized_main_thread!();
         let tmp = unsafe { ffi::gtk_tree_path_new() };
 
         if tmp.is_null() {
@@ -24,6 +25,7 @@ impl TreePath {
     }
 
     pub fn new_from_string(path: &str) -> Option<TreePath> {
+        assert_initialized_main_thread!();
         let tmp = unsafe {
             ffi::gtk_tree_path_new_from_string(path.to_glib_none().0)
         };
@@ -39,6 +41,7 @@ impl TreePath {
 
     #[cfg(gtk_3_12)]
     pub fn new_from_indicesv(indices: &mut [i32]) -> Option<TreePath> {
+        assert_initialized_main_thread!();
         let tmp = unsafe { ffi::gtk_tree_path_new_from_indicesv(indices.as_mut_ptr(), indices.len() as ::libc::size_t) };
 
         if tmp.is_null() {
@@ -51,6 +54,7 @@ impl TreePath {
     }
 
     pub fn new_first() -> Option<TreePath> {
+        assert_initialized_main_thread!();
         let tmp = unsafe { ffi::gtk_tree_path_new_first() };
 
         if tmp.is_null() {

--- a/src/widgets/tree_selection.rs
+++ b/src/widgets/tree_selection.rs
@@ -103,11 +103,11 @@ impl TreeSelection {
             end_path.unwrap_pointer()) }
     }
 
-    pub fn wrap(pointer: *mut ffi::GtkTreeSelection) -> Option<TreeSelection> {
+    pub unsafe fn wrap(pointer: *mut ffi::GtkTreeSelection) -> Option<TreeSelection> {
         if pointer.is_null() {
             None
         } else {
-            unsafe { ::gobject_ffi::g_object_ref(pointer as *mut _); }
+            ::gobject_ffi::g_object_ref(pointer as *mut _);
             Some(TreeSelection { pointer: pointer })
         }
     }
@@ -118,8 +118,8 @@ impl glib::traits::FFIGObject for TreeSelection {
         ::cast::G_OBJECT_FROM_TREE_SELECTION(self.pointer)
     }
 
-    fn wrap_object(object: *mut ::gobject_ffi::GObject) -> TreeSelection {
-        unsafe { ::gobject_ffi::g_object_ref(object as *mut _); }
+    unsafe fn wrap_object(object: *mut ::gobject_ffi::GObject) -> TreeSelection {
+        ::gobject_ffi::g_object_ref(object as *mut _);
         TreeSelection { pointer: object as *mut ffi::GtkTreeSelection }
     }
 }

--- a/src/widgets/tree_store.rs
+++ b/src/widgets/tree_store.rs
@@ -16,6 +16,7 @@ pub struct TreeStore {
 
 impl TreeStore {
     pub fn new(column_types: &[Type]) -> Option<TreeStore> {
+        assert_initialized_main_thread!();
         let column_types_ffi: Vec<GType> = column_types.iter().map(|n| n.to_glib()).collect();
         let tmp_pointer = unsafe { ffi::gtk_tree_store_newv(column_types.len() as i32, column_types_ffi.as_ptr() as *mut GType) };
         check_pointer!(tmp_pointer, TreeStore, G_OBJECT_FROM_TREE_STORE)

--- a/src/widgets/tree_store.rs
+++ b/src/widgets/tree_store.rs
@@ -165,10 +165,10 @@ impl TreeStore {
         if self.pointer.is_null() {
             None
         } else {
-            let tmp = ::cast::GTK_TREE_MODEL_FROM_TREE_STORE(self.pointer);
-
-            unsafe { ::gobject_ffi::g_object_ref(tmp as *mut _) };
-            Some(::TreeModel::wrap_pointer(tmp))
+            unsafe {
+                let tmp = ::cast::GTK_TREE_MODEL_FROM_TREE_STORE(self.pointer);
+                Some(::TreeModel::wrap_pointer(tmp))
+            }
         }
     }
 
@@ -195,7 +195,7 @@ impl TreeStore {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(c_treestore: *mut ffi::GtkTreeStore) -> TreeStore {
+    pub unsafe fn wrap_pointer(c_treestore: *mut ffi::GtkTreeStore) -> TreeStore {
         TreeStore {
             pointer: c_treestore
         }

--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -355,13 +355,13 @@ impl TreeView {
     }
 
     pub fn get_model(&self) -> Option<::TreeModel> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_view_get_model(GTK_TREE_VIEW(self.pointer)) };
-
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            unsafe { ::gobject_ffi::g_object_ref(tmp_pointer as *mut _) };
-            Some(::TreeModel::wrap_pointer(tmp_pointer))
+        unsafe {
+            let ptr = ffi::gtk_tree_view_get_model(GTK_TREE_VIEW(self.pointer));
+            if ptr.is_null() {
+                None
+            } else {
+                Some(::TreeModel::wrap_pointer(ptr))
+            }
         }
     }
 
@@ -380,9 +380,10 @@ impl TreeView {
     }
 
     pub fn get_selection(&self) -> Option<TreeSelection> {
-        let tmp_pointer = unsafe { ffi::gtk_tree_view_get_selection(GTK_TREE_VIEW(self.pointer)) };
-
-        TreeSelection::wrap(tmp_pointer)
+        unsafe {
+            let ptr = ffi::gtk_tree_view_get_selection(GTK_TREE_VIEW(self.pointer));
+            TreeSelection::wrap(ptr)
+        }
     }
 
     pub fn set_cursor(&self, path: &TreePath, focus_column: Option<&TreeViewColumn>, start_editing: bool) {

--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -15,11 +15,13 @@ struct_Widget!(TreeView);
 
 impl TreeView {
     pub fn new() -> Option<TreeView> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_tree_view_new() };
         check_pointer!(tmp_pointer, TreeView)
     }
 
     pub fn new_with_model(model: &::TreeModel) -> Option<TreeView> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_tree_view_new_with_model(model.unwrap_pointer()) };
         check_pointer!(tmp_pointer, TreeView)
     }

--- a/src/widgets/tree_view_column.rs
+++ b/src/widgets/tree_view_column.rs
@@ -16,6 +16,7 @@ pub struct TreeViewColumn {
 
 impl TreeViewColumn {
     pub fn new() -> Option<TreeViewColumn> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_tree_view_column_new() };
         check_pointer!(tmp_pointer, TreeViewColumn, G_OBJECT_FROM_TREE_VIEW_COLUMN)
     }

--- a/src/widgets/tree_view_column.rs
+++ b/src/widgets/tree_view_column.rs
@@ -294,11 +294,8 @@ impl TreeViewColumn {
     }
 
     #[doc(hidden)]
-    pub fn wrap_pointer(treeview_column: *mut ffi::GtkTreeViewColumn) -> TreeViewColumn {
-        unsafe{
-            ::gobject_ffi::g_object_ref(treeview_column as *mut _);
-        }
-
+    pub unsafe fn wrap_pointer(treeview_column: *mut ffi::GtkTreeViewColumn) -> TreeViewColumn {
+        ::gobject_ffi::g_object_ref(treeview_column as *mut _);
         TreeViewColumn {
             pointer: treeview_column
         }
@@ -310,7 +307,7 @@ impl glib::traits::FFIGObject for TreeViewColumn {
         ::cast::G_OBJECT_FROM_TREE_VIEW_COLUMN(self.pointer)
     }
 
-    fn wrap_object(object: *mut ::gobject_ffi::GObject) -> TreeViewColumn {
+    unsafe fn wrap_object(object: *mut ::gobject_ffi::GObject) -> TreeViewColumn {
         TreeViewColumn { pointer: object as *mut ffi::GtkTreeViewColumn }
     }
 }

--- a/src/widgets/viewport.rs
+++ b/src/widgets/viewport.rs
@@ -13,6 +13,7 @@ struct_Widget!(Viewport);
 
 impl Viewport {
     pub fn new(hadjustment: &::Adjustment, vadjustment: &::Adjustment) -> Option<Viewport> {
+        skip_assert_initialized!();
         let tmp_pointer = unsafe { ffi::gtk_viewport_new(hadjustment.unwrap_pointer(), vadjustment.unwrap_pointer()) };
         check_pointer!(tmp_pointer, Viewport)
     }

--- a/src/widgets/volume_button.rs
+++ b/src/widgets/volume_button.rs
@@ -11,6 +11,7 @@ struct_Widget!(VolumeButton);
 
 impl VolumeButton {
     pub fn new() -> Option<VolumeButton> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_volume_button_new() };
         check_pointer!(tmp_pointer, VolumeButton)
     }

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -20,6 +20,7 @@ struct_Widget!(Window);
 
 impl Window {
     pub fn new(window_type: WindowType) -> Option<Window> {
+        assert_initialized_main_thread!();
         let tmp_pointer = unsafe { ffi::gtk_window_new(window_type) };
         check_pointer!(tmp_pointer, Window)
     }


### PR DESCRIPTION
 * Assert that GTK is initialized in constructors and free functions.
 * Prevent unwinding across FFI.
 * Make `main_quit` safe.

Fix #187 and #188 