### PR TITLE
Add gtk::Window::new() example

### DIFF
--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -16,6 +16,20 @@ use WindowType;
 */
 struct_Widget!(Window);
 
+/// Go to the  GTK website for complete
+/// [documentation](https://developer.gnome.org/gtk3/stable/GtkWindow.html).
+///
+/// # Examples
+///
+/// ```
+/// use gtk::traits::*;
+///
+/// gtk::init();
+/// let window = gtk::Window::new(gtk::WindowType::Toplevel).unwrap();
+/// window.set_window_position(gtk::WindowPosition::Center);
+/// window.show_all();
+/// ```
+///
 impl Window {
     pub fn new(window_type: WindowType) -> Option<Window> {
         assert_initialized_main_thread!();


### PR DESCRIPTION
I found it frustrating to not have any examples to go along with the documentation so I added a link to the GTK site and added an example of how to create a window. If this is useful, I can add examples and links for some other widgets.