### PR TITLE
Added signals for MenuItem and EntryCompletion

### DIFF
--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -52,6 +52,10 @@ pub use signal::{
     ButtonSignals,
     CalendarSignals,
     ComboBoxSignals,
+    EntrySignals,
+    EntryCompletionSignals,
+    MenuItemSignals,
+    TextBufferSignals, 
     ToolButtonSignals,
 };
 


### PR DESCRIPTION
A few more signals, this time to be notified of menu clicks via the "activate" signal on `MenuItem`, and to get `EntryCompletion`'s "match-selected" signal when the user picks one of the `EntryCompletion`'s options.

I also tried to fit it in better with the way the signals are reexported from traits/mod.rs.