### PR TITLE
Update version number in README's Cargo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Examples of gtk applications can be found in the [examples repository](https://g
 To include gtk as a cargo dependency you have to add it to your Cargo.toml:
 ```Toml
 [dependencies]
-gtk = "0.0.4"
+gtk = "0.0"
 ```
 
 ## Use __gtk__


### PR DESCRIPTION
A minor point obviously, but I followed the README blindly and got bit because 0.0.4 won't build some reason. Not sure why that was, but in any case 0.0.6 built just fine.

Specifying 0.0 still allows for 0.1 to break APIs, but grabs the latest 0.0.* patch version. Seems like the desired behaviour, and it avoids the issue of forgetting to update this bit again when future versions come out.