### PR TITLE
Update README.md - in Windows msys2 instructions, specify that PATH needs to be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ or follow these steps:
  ```Shell
  $ pacman -S mingw-w64-x86_64-gtk3
  ```
+ 
+Make sure that either `<your msys installation folder>\mingw32\bin` or `<your msys installation folder>msys32\mingw64\bin` is in your `PATH` e.g. (if you have msys32 installed at `c:\msys32`, add `c:\msys32\mingw32\bin` or `c:\msys32\mingw64\bin` to your `PATH`)
 
 #### 2. separate mingw toolchain
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ or follow these steps:
  $ pacman -S mingw-w64-x86_64-gtk3
  ```
  
-Make sure that either `<your msys installation folder>\mingw32\bin` or `<your msys installation folder>msys32\mingw64\bin` is in your `PATH` e.g. (if you have msys32 installed at `c:\msys32`, add `c:\msys32\mingw32\bin` or `c:\msys32\mingw64\bin` to your `PATH`)
+Make sure that either `<your msys installation folder>\mingw32\bin` or `<your msys installation folder>\mingw64\bin` is in your `PATH` e.g. (if you have msys32 installed at `c:\msys32`, add `c:\msys32\mingw32\bin` or `c:\msys32\mingw64\bin` to your `PATH`).
 
 #### 2. separate mingw toolchain
 


### PR DESCRIPTION
I had problems getting rgtk to build on Windows. I eventually resolved it by adding C:\msys32\mingw32\bin to the path. I think it would be useful to add that to the instructions under msys2 for windows. 