### PR TITLE
Reexport the new trait `Cast` and put it in the prelude

### DIFF
--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -3,12 +3,12 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use ffi;
+use glib::object::Downcast;
 use glib::translate::*;
 use std::ptr;
 use Box;
 use Dialog;
 use DialogFlags;
-use Downcast;
 use Upcast;
 use Widget;
 use Window;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate pango;
 pub use gdk::pixbuf as gdk_pixbuf;
 
 pub use glib::{
-    Downcast,
+    Cast,
     Error,
     Object,
     Upcast,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,8 +3,7 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 pub use {
-    Downcast,
-    Upcast,
+    Cast,
 };
 
 #[cfg(gtk_3_4)]


### PR DESCRIPTION
Remove `Downcast` reexport.
`Cast` provides generic `upcast` and `downcast` methods.