### PR TITLE
Implement `embed-lgpl-docs` and `purge-lgpl-docs` features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ addons:
 script:
   - rustc --version
   - ./check_init_asserts
+  - cargo test --features embed-lgpl-docs
+  # catch any sneaked in lgpl docs
+  - cargo build --features purge-lgpl-docs
+  - git diff -R --exit-code
   - mkdir .cargo
   - echo 'paths = ["."]' > .cargo/config
   - git clone -q --depth 50 -b pending https://github.com/rust-gnome/examples _examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gtk"
 version = "0.0.7"
 authors = ["The Gtk-rs Project Developers"]
+build = "build.rs"
 
 description = "Rust bindings for the GTK+ library"
 repository = "https://github.com/gtk-rs/gtk"
@@ -23,6 +24,15 @@ name = "gtk"
 "3.12" = ["3.10", "gtk-sys/3.12", "gdk/3.12"]
 "3.14" = ["3.12", "gtk-sys/3.14", "gdk/3.14"]
 "3.16" = ["3.14", "gtk-sys/3.16", "gdk/3.16"]
+# Embed the LGPL-licensed doc-comments into the sources
+embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
+# Remove the LGPL-licensed doc-comments
+purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
+
+[build-dependencies.gtk-rs-lgpl-docs]
+git = "https://github.com/gtk-rs/lgpl-docs"
+version = "0.0.1"
+optional = true
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ gdk = "0.2"
 gtk = { git = "https://github.com/gtk-rs/gtk.git" }
 ```
 
+## Documentation
+
+The majority of the documentation is kept [in a separate repo][gtk-md] due to
+licensing issues. You can pull it in with cargo:
+
+```shell
+> cargo build --embed-lgpl-docs
+```
+
+Changes to those doc-comments should be submitted to the `lgpl-docs` repo. Avoid
+including those embedded doc-comments in PRs to this repo.
+
+The opposite feature removes all of those docs regardless of edits:
+
+```shell
+> cargo build --purge-lgpl-docs
+```
+
+These features **rewrite the crate sources** so it's sufficient to enable them
+once. **Omitting them in the following `cargo` invocations will not undo their
+effects!**
+
+[gtk-md]: https://github.com/gtk-rs/lgpl-docs/blob/master/gtk.md
+
 ## Contribute
 
 Contributor you're welcome!

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    manage_docs();
+}
+
+#[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
+fn manage_docs () {
+    extern crate lgpl_docs;
+    const PATH: &'static str = "src";
+    const IGNORES: &'static [&'static str] = &[
+        "lib.rs",
+        "rt.rs",
+        "signal.rs",
+    ];
+    lgpl_docs::purge(PATH, IGNORES);
+    if cfg!(feature = "embed-lgpl-docs") {
+        lgpl_docs::embed(lgpl_docs::GTK_DOCS, PATH, IGNORES);
+    }
+}
+
+#[cfg(not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs")))]
+fn manage_docs() { }


### PR DESCRIPTION
Part of #8

`embed-lgpl-docs`: embed documentation comments contained in the gtk-rs-lgpl-docs package into the sources.
`purge-lgpl-docs`: remove all LGPL doc comments from the source.