### PR TITLE
Remove GTK_LIB_DIR from appveyor it's no longer required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Breaking changes
 
-- Version features [have been reintroduced][gtk248] and autodetection is no more. The fallback version is 3.4.
+- Version features [have been reintroduced][gtk248] and autodetection is no
+  more. The fallback version is 3.4.
 
     Select the minimal version required by your application like this:
     ```toml
@@ -10,7 +11,15 @@
     features = ["3.10"]
     ```
 
-    Windows users should set `GTK_LIB_DIR` and use Rust's bundled gcc.
+- Windows users should use Rust's bundled gcc instead of deleting it.
+
+### Improvements
+
+- In the absence of `pkg-config` we try to link anyway assuming the libraries
+  can be found in the default search path. There are no version checks in this
+  case.
+
+- Setting `GTK_LIB_DIR` skips `pkg-config` altogether.
 
 - TBD
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ install:
   - IF "%BITS%" == "32" SET ARCH=i686
   - IF "%BITS%" == "64" SET ARCH=x86_64
   - SET RUST_URL=https://static.rust-lang.org/dist/rust-%RUST%-%ARCH%-pc-windows-gnu.exe
-  - SET GTK_LIB_DIR=C:\msys64\mingw%BITS%\lib
   - SET PATH=C:\Rust\bin;C:\msys64\mingw%BITS%\bin;%PATH%;C:\msys64\usr\bin
   - ps: Start-FileDownload $Env:RUST_URL -FileName rust-dist.exe
   - rust-dist.exe /VERYSILENT /NORESTART /COMPONENTS="Rustc,Gcc,Cargo,Std" /DIR="C:\Rust"


### PR DESCRIPTION
Also update the changelog a bit