### PR TITLE
Reexport `glib::prelude::*` in the prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,9 @@
   - Unified upcasting and downcasting via the `Cast` trait, proper interface
     support. In particular this makes `Builder` safe to use.
 
-  - The [`prelude`][prelude] module, which reexports all traits from `gtk` and
-    its dependencies and some ubiquitous types (`Continue`, `Inhibit`).
+  - Each crate has a `prelude` module, which reexports all traits and some
+    ubiquitous types (`Continue`, `Inhibit`). `gtk`'s prelude incorporates
+    `glib`'s one.
 
   - Removal of the C glue layer and gcc dependency.
 

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn manage_docs () {
     const PATH: &'static str = "src";
     const IGNORES: &'static [&'static str] = &[
         "lib.rs",
+        "prelude.rs",
         "rt.rs",
         "signal.rs",
     ];

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,12 +2,9 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-pub use {
-    Cast,
-    Continue,
-    StaticType,
-    ToValue,
-};
+//! Traits and essential types inteded for blanket imports.
+
+pub use glib::prelude::*;
 
 #[cfg(feature = "3.4")]
 pub use auto::traits::ActionableExt;


### PR DESCRIPTION
I've changed my mind about reexporting all preludes here so adjusted the changelog.