### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/list_store.rs
+++ b/src/list_store.rs
@@ -37,7 +37,7 @@ impl ListStore {
             let mut iter = TreeIter::uninitialized();
             ffi::gtk_list_store_insert_with_valuesv(self.to_glib_none().0,
                 iter.to_glib_none_mut().0,
-                position.map(|n| n as c_int).unwrap_or(-1),
+                position.map_or(-1, |n| n as c_int),
                 mut_override(columns.as_ptr() as *const c_int),
                 values.to_glib_none().0,
                 columns.len() as c_int);
@@ -55,11 +55,10 @@ impl ListStore {
                           new_order.len());
             let safe_values = new_order.iter()
                 .max()
-                .map(|&max| {
+                .map_or(true, |&max| {
                     let max = max as i32;
                     max >= 0 && max < count
-                })
-                .unwrap_or(true);
+                });
             debug_assert!(safe_values,
                           "Some `new_order` slice values are out of range. Maximum safe value: \
                            `{}`. The slice contents: `{:?}`",

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -56,7 +56,7 @@ impl Notebook {
         unsafe {
             from_glib_none(
                 ffi::gtk_notebook_get_nth_page(self.to_glib_none().0,
-                    page_num.map(|n| n as c_int).unwrap_or(-1)))
+                    page_num.map_or(-1, |n| n as c_int)))
         }
     }
 
@@ -67,7 +67,7 @@ impl Notebook {
           U: IsA<Widget> {
         unsafe {
             let ret = ffi::gtk_notebook_insert_page(self.to_glib_none().0, child.to_glib_none().0,
-                tab_label.to_glib_none().0, position.map(|n| n as c_int).unwrap_or(-1));
+                tab_label.to_glib_none().0, position.map_or(-1, |n| n as c_int));
             assert!(ret >= 0);
             ret as u32
         }
@@ -81,7 +81,7 @@ impl Notebook {
         unsafe {
             let ret = ffi::gtk_notebook_insert_page_menu(self.to_glib_none().0,
                 child.to_glib_none().0, tab_label.to_glib_none().0, menu_label.to_glib_none().0,
-                position.map(|n| n as c_int).unwrap_or(-1));
+                position.map_or(-1, |n| n as c_int));
             assert!(ret >= 0);
             ret as u32
         }
@@ -125,21 +125,21 @@ impl Notebook {
     pub fn remove_page(&self, page_num: Option<u32>) {
         unsafe {
             ffi::gtk_notebook_remove_page(self.to_glib_none().0,
-                page_num.map(|n| n as c_int).unwrap_or(-1));
+                page_num.map_or(-1, |n| n as c_int));
         }
     }
 
     pub fn reorder_child<T: IsA<Widget>>(&self, child: &T, position: Option<u32>) {
         unsafe {
             ffi::gtk_notebook_reorder_child(self.to_glib_none().0, child.to_glib_none().0,
-                position.map(|n| n as c_int).unwrap_or(-1));
+                position.map_or(-1, |n| n as c_int));
         }
     }
 
     pub fn set_current_page(&self, page_num: Option<u32>) {
         unsafe {
             ffi::gtk_notebook_set_current_page(self.to_glib_none().0,
-                page_num.map(|n| n as c_int).unwrap_or(-1));
+                page_num.map_or(-1, |n| n as c_int));
         }
     }
 }

--- a/src/recent_info.rs
+++ b/src/recent_info.rs
@@ -71,11 +71,12 @@ impl RecentInfo {
             let mut count = 0;
             let mut time_ = 0;
 
-            match from_glib(ffi::gtk_recent_info_get_application_info(
+            if from_glib(ffi::gtk_recent_info_get_application_info(
                     self.to_glib_none().0, app_name.to_glib_none().0,
                     &mut app_exec, &mut count, &mut time_)) {
-                true => Some((from_glib_none(app_exec), count, time_ as u64)),
-                _ => None
+                Some((from_glib_none(app_exec), count, time_ as u64))
+            } else {
+                None
             }
         }
     }

--- a/src/tree_store.rs
+++ b/src/tree_store.rs
@@ -36,7 +36,7 @@ impl TreeStore {
             ffi::gtk_tree_store_insert_with_valuesv(self.to_glib_none().0,
                 iter.to_glib_none_mut().0,
                 mut_override(parent.to_glib_none().0),
-                position.map(|n| n as c_int).unwrap_or(-1),
+                position.map_or(-1, |n| n as c_int),
                 mut_override(columns.as_ptr() as *const c_int),
                 values.to_glib_none().0,
                 columns.len() as c_int);
@@ -55,11 +55,10 @@ impl TreeStore {
                           new_order.len());
             let safe_values = new_order.iter()
                 .max()
-                .map(|&max| {
+                .map_or(true, |&max| {
                     let max = max as i32;
                     max >= 0 && max < count
-                })
-                .unwrap_or(true);
+                });
             debug_assert!(safe_values,
                           "Some `new_order` slice values are out of range. Maximum safe value: \
                            `{}`. The slice contents: `{:?}`",


### PR DESCRIPTION
Mostly this changes `_.map(..).unwrap_or(_)`  to `_.map_or(_, ..)` in a few places.

There are a *lot* of warnings suggesting adding `Default` impls for most types (which may or may not be useful, I have not looked too closely into the codebase), also unrelated to clippy, there are a lot of transmute warnings on nightly, but I'm unsure if this is in generated code.