### PR TITLE
Update appveyor builds to use rust 1.8.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - RUST: 1.6.0
+    - RUST: 1.8.0
       BITS: 32
-    - RUST: 1.6.0
+    - RUST: 1.8.0
       BITS: 64
 
 install:


### PR DESCRIPTION
This should fix the failing appveyor build in #306.