### PR TITLE
Rewrite makefile to use `cargo install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
-GIR = gir/target/release/gir
-GTK_GIR = gir-files/Gtk-3.0.gir
+GIR = gir/target/bin/gir
+GIR_SRC = gir/Cargo.toml gir/Cargo.lock gir/build.rs $(shell find gir/src -name '*.rs')
+GIR_FILES = gir-files/Gtk-3.0.gir
 
 # Run `gir` generating the bindings
 gir : src/auto/mod.rs
 
-src/auto/mod.rs : Gir.toml $(GIR) $(GTK_GIR)
+src/auto/mod.rs : Gir.toml $(GIR) $(GIR_FILES)
 	$(GIR) -c Gir.toml
 
-$(GIR) : gir/Cargo.toml gir/Cargo.lock gir/build.rs $(shell find gir/src -name '*.rs')
-	cd gir && cargo build --release
+$(GIR) : $(GIR_SRC)
+	rm -f gir/target/bin/gir
+	cargo install --path gir --root gir/target
+	rm -f gir/target/.crates.toml
 
-gir/Cargo.toml $(GTK_GIR) :
+$(GIR_SRC) $(GIR_FILES) :
 	git submodule update --init


### PR DESCRIPTION
This makes gir build work regardless of any `target-dir` overrides.

This could mitigate #311.
By adding a `.cargo/config` with a `target-dir` override you can avoid target directiry duplication and unnecessary rebuilds of gir dependencies.

For example, putting
```toml
[build]
# the './' is important here
target-dir = "./target"
```
in `../.cargo/config` (relatively to this repo root) you make all gtk-rs and gir builds use the same target directory.