### PR TITLE
Implement Into<i32> for IconSize and ResponseType

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,0 +1,15 @@
+use glib::translate::ToGlib;
+
+impl Into<i32> for ::IconSize {
+    fn into(self) -> i32 {
+        skip_assert_initialized!();
+        self.to_glib() as i32
+    }
+}
+
+impl Into<i32> for ::ResponseType {
+    fn into(self) -> i32 {
+        skip_assert_initialized!();
+        self.to_glib() as i32
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ mod color_button;
 mod color_chooser;
 mod dialog;
 mod entry_buffer;
+mod enums;
 mod file_chooser_dialog;
 mod list_store;
 mod message_dialog;


### PR DESCRIPTION
Preserve a way to pass these to functions that take `i32` until the generator supports rewriting types.