### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ v3_12 = ["v3_10", "gtk-sys/v3_12", "gdk/v3_12"]
 v3_14 = ["v3_12", "gtk-sys/v3_14", "gdk/v3_14"]
 v3_16 = ["v3_14", "gtk-sys/v3_16", "gdk/v3_16"]
 
+[profile.release]
+lto = true
+
 [build-dependencies.gtk-rs-lgpl-docs]
 git = "https://github.com/gtk-rs/lgpl-docs"
 version = "0.1.0"


### PR DESCRIPTION
I read this very interesting [article](https://lifthrasiir.github.io/rustlog/why-is-a-rust-executable-large.html) which talked about having more little executables. I was wondering if we could bring this in gtk as well (and if it would be useful).

cc @gkoz 
cc @EPashkin 
