### PR TITLE
Tree sortable ignore get sort column

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -1141,7 +1141,7 @@ status = "generate"
 name = "Gtk.TreeSortable"
 status = "generate"
     [[object.function]]
-    name = "set_sort_column_id"
+    pattern = "[gs]et_sort_column_id"
     ignore = true
 
 [[object]]

--- a/src/auto/tree_sortable.rs
+++ b/src/auto/tree_sortable.rs
@@ -2,7 +2,6 @@
 // DO NOT EDIT
 
 use Object;
-use SortType;
 use TreeModel;
 use ffi;
 use glib::object::Downcast;
@@ -11,7 +10,6 @@ use glib::signal::connect;
 use glib::translate::*;
 use glib_ffi;
 use std::boxed::Box as Box_;
-use std::mem;
 use std::mem::transmute;
 
 glib_wrapper! {
@@ -23,8 +21,6 @@ glib_wrapper! {
 }
 
 pub trait TreeSortableExt {
-    fn get_sort_column_id(&self) -> Option<(i32, SortType)>;
-
     fn has_default_sort_func(&self) -> bool;
 
     //fn set_default_sort_func(&self, sort_func: /*Unknown conversion*//*Unimplemented*/TreeIterCompareFunc, user_data: /*Unimplemented*/Option<Fundamental: Pointer>, destroy: /*Unknown conversion*//*Unimplemented*/DestroyNotify);
@@ -37,15 +33,6 @@ pub trait TreeSortableExt {
 }
 
 impl<O: IsA<TreeSortable> + IsA<Object>> TreeSortableExt for O {
-    fn get_sort_column_id(&self) -> Option<(i32, SortType)> {
-        unsafe {
-            let mut sort_column_id = mem::uninitialized();
-            let mut order = mem::uninitialized();
-            let ret = from_glib(ffi::gtk_tree_sortable_get_sort_column_id(self.to_glib_none().0, &mut sort_column_id, &mut order));
-            if ret { Some((sort_column_id, from_glib(order))) } else { None }
-        }
-    }
-
     fn has_default_sort_func(&self) -> bool {
         unsafe {
             from_glib(ffi::gtk_tree_sortable_has_default_sort_func(self.to_glib_none().0))


### PR DESCRIPTION
@GuillaumeGomez, I just don't remember why get was not ignored.
May be it was some reason (backward compatibility etc.)?