### PR TITLE
Add to categories for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 authors = ["The Gtk-rs Project Developers"]
 build = "build.rs"
 
+categories = ["api-bindings", "gui"]
 description = "Rust bindings for the GTK+ 3 library"
 repository = "https://github.com/gtk-rs/gtk"
 license = "MIT"


### PR DESCRIPTION
Haven't tested this since you need to publish a new version, but this should put it in the [GUI category](https://crates.io/categories/gui).