### PR TITLE
Use glib::BoolError for gtk::init() and gtk::Application::new()

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -4,27 +4,29 @@ use gio::ApplicationFlags;
 use glib::object::IsA;
 use glib::translate::*;
 use rt;
+use glib;
+use glib_ffi;
 
 impl Application {
     #[cfg(feature = "v3_6")]
-    fn new(application_id: Option<&str>, flags: ApplicationFlags) -> Result<Application, ()> {
+    fn new(application_id: Option<&str>, flags: ApplicationFlags) -> Result<Application, glib::BoolError> {
         skip_assert_initialized!();
         try!(rt::init());
         unsafe {
             Option::from_glib_full(
                 ffi::gtk_application_new(application_id.to_glib_none().0, flags.to_glib()))
-                .ok_or(())
+                .ok_or(glib::BoolError("Failed to create application"))
         }
     }
 
     #[cfg(not(feature = "v3_6"))]
-    fn new(application_id: &str, flags: ApplicationFlags) -> Result<Application, ()> {
+    fn new(application_id: &str, flags: ApplicationFlags) -> Result<Application, glib::BoolError> {
         skip_assert_initialized!();
         try!(rt::init());
         unsafe {
             Option::from_glib_full(
                 ffi::gtk_application_new(application_id.to_glib_none().0, flags.to_glib()))
-                .ok_or(())
+                .ok_or(glib::BoolError("Failed to create application"))
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -5,15 +5,7 @@ use glib::object::IsA;
 use glib::translate::*;
 use rt;
 
-pub trait ApplicationExtManual {
-    #[cfg(feature = "v3_6")]
-    fn new(application_id: Option<&str>, flags: ApplicationFlags) -> Result<Application, ()>;
-
-    #[cfg(not(feature = "v3_6"))]
-    fn new(application_id: &str, flags: ApplicationFlags) -> Result<Application, ()>;
-}
-
-impl<O: IsA<Application>> ApplicationExtManual for O {
+impl Application {
     #[cfg(feature = "v3_6")]
     fn new(application_id: Option<&str>, flags: ApplicationFlags) -> Result<Application, ()> {
         skip_assert_initialized!();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,6 @@ pub use glib::prelude::*;
 pub use auto::traits::*;
 
 pub use app_chooser::AppChooserExt;
-pub use application::ApplicationExtManual;
 pub use assistant::AssistantExtManual;
 pub use clipboard::ClipboardExtManual;
 pub use color_button::ColorButtonExtManual;

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 use libc::{c_int, c_uint};
 use ffi;
 use glib::translate::*;
+use glib;
 use gdk;
 
 thread_local! {
@@ -94,7 +95,7 @@ pub unsafe fn set_initialized() {
 /// so will not cause the program to terminate if GTK could not be initialized.
 /// Instead, an Ok is returned if the windowing system was successfully
 /// initialized otherwise an Err is returned.
-pub fn init() -> Result<(), ()> {
+pub fn init() -> Result<(), glib::BoolError> {
     skip_assert_initialized!();
     if is_initialized_main_thread() {
         return Ok(());
@@ -108,7 +109,7 @@ pub fn init() -> Result<(), ()> {
             Ok(())
         }
         else {
-            Err(())
+            Err(glib::BoolError("Failed to initialize GTK"))
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/gtk-rs/glib/pull/179

Also removes the useless ApplicationExtManual trait