### PR TITLE
Make location in TextBuffer insert-text callback mutable.

### DIFF
--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -16,13 +16,13 @@ use TextBuffer;
 use TextIter;
 
 pub trait TextBufferExtManual {
-    fn connect_insert_text<F: Fn(&TextBuffer, &TextIter, &str) + 'static>(&self, f: F) -> SignalHandlerId;
+    fn connect_insert_text<F: Fn(&TextBuffer, &mut TextIter, &str) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
 impl<O: IsA<TextBuffer> + IsA<glib::object::Object>> TextBufferExtManual for O {
-    fn connect_insert_text<F: Fn(&TextBuffer, &TextIter, &str) + 'static>(&self, f: F) -> SignalHandlerId {
+    fn connect_insert_text<F: Fn(&TextBuffer, &mut TextIter, &str) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe {
-            let f: Box_<Box_<Fn(&TextBuffer, &TextIter, &str) + 'static>> = Box_::new(Box_::new(f));
+            let f: Box_<Box_<Fn(&TextBuffer, &mut TextIter, &str) + 'static>> = Box_::new(Box_::new(f));
             connect(self.to_glib_none().0, "insert-text",
                 transmute(insert_text_trampoline as usize), Box_::into_raw(f) as *mut _)
         }
@@ -37,6 +37,6 @@ unsafe extern "C" fn insert_text_trampoline(this: *mut ffi::GtkTextBuffer,
     callback_guard!();
     let f: &&(Fn(&TextBuffer, &TextIter, &str) + 'static) = transmute(f);
     f(&from_glib_borrow(this),
-      &from_glib_borrow(location),
+      &mut from_glib_borrow(location),
       str::from_utf8(slice::from_raw_parts(text as *const u8, len as usize)).unwrap())
 }


### PR DESCRIPTION
Make it possible to revalidate the iterator position with `iter.assign(&new_iter)`
in the case the callback has to make additional changes to buffer.

Fixes issue #646.

Warning: It is also possible to write `*iter = new_iter`,
but that does something completely different than assign.