### PR TITLE
let applicationwindow accept anything implementing Application

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -18,7 +18,6 @@ generate = [
     "Gtk.AppChooserButton",
     "Gtk.AppChooserWidget",
     "Gtk.ApplicationInhibitFlags",
-    "Gtk.ApplicationWindow",
     "Gtk.Arrow",
     "Gtk.ArrowType",
     "Gtk.AspectFrame",
@@ -417,6 +416,13 @@ status = "generate"
 name = "Gtk.Application"
 status = "generate"
 trait_name = "GtkApplicationExt"
+    [[object.function]]
+    name = "new"
+    ignore = true
+
+[[object]]
+name = "Gtk.ApplicationWindow"
+status = "generate"
     [[object.function]]
     name = "new"
     ignore = true
@@ -1483,7 +1489,7 @@ status = "generate"
     [[object.signal]]
     name = "insert-emoji"
     #actually Since 3.22.27
-    version = "3.22.26" 
+    version = "3.22.26"
 
 [[object]]
 name = "Gtk.TextViewLayer"

--- a/src/application_window.rs
+++ b/src/application_window.rs
@@ -1,0 +1,18 @@
+use ApplicationWindow;
+use Application;
+use Widget;
+
+use ffi;
+use glib::object::Downcast;
+use glib::object::IsA;
+use glib::translate::*;
+
+
+impl ApplicationWindow {
+    pub fn new<P: IsA<Application>>(application: &P) -> ApplicationWindow {
+        skip_assert_initialized!();
+        unsafe {
+            Widget::from_glib_none(ffi::gtk_application_window_new(application.to_glib_none().0)).downcast_unchecked()
+        }
+    }
+}

--- a/src/auto/application_window.rs
+++ b/src/auto/application_window.rs
@@ -2,7 +2,6 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-use Application;
 use Bin;
 use Buildable;
 use Container;
@@ -39,15 +38,6 @@ glib_wrapper! {
 
     match fn {
         get_type => || ffi::gtk_application_window_get_type(),
-    }
-}
-
-impl ApplicationWindow {
-    pub fn new(application: &Application) -> ApplicationWindow {
-        skip_assert_initialized!();
-        unsafe {
-            Widget::from_glib_none(ffi::gtk_application_window_new(application.to_glib_none().0)).downcast_unchecked()
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@ mod auto;
 
 mod app_chooser;
 mod application;
+mod application_window;
 mod assistant;
 mod buildable;
 mod builder;


### PR DESCRIPTION
As mentioned in gtk-rs/gtk#658, gtk::ApplicationWindow should accept anything that IsA<gtk::Application>.