### PR TITLE
Add manual implementation of EntryCompletion::set_match_func

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,10 @@ script:
     make regen_check;
     fi
   - ./check_init_asserts
-  - cargo install clippy || touch clippy_failed
-  - if [ ! -f clippy_failed ]; then cargo clippy; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ] && [ "$GTK" == "3.4" ]; then
+    rustup component add clippy-preview;
+    cargo clippy;
+    fi
   - cargo test --features embed-lgpl-docs --jobs 1
   - cargo doc --features "dox"
   # catch any sneaked in lgpl docs

--- a/Gir.toml
+++ b/Gir.toml
@@ -769,6 +769,9 @@ status = "generate"
     [[object.signal]]
     name = "cursor-on-match"
     inhibit = true
+    [[object.function]]
+    name = "set_match_func"
+    ignore = true # manual implementation as a test for now
 
 [[object]]
 name = "Gtk.Expander"

--- a/src/auto/entry_completion.rs
+++ b/src/auto/entry_completion.rs
@@ -93,8 +93,6 @@ pub trait EntryCompletionExt {
 
     fn set_inline_selection(&self, inline_selection: bool);
 
-    //fn set_match_func<P: Into<Option</*Unimplemented*/Fundamental: Pointer>>>(&self, func: /*Unknown conversion*//*Unimplemented*/EntryCompletionMatchFunc, func_data: P, func_notify: /*Unknown conversion*//*Unimplemented*/DestroyNotify);
-
     fn set_minimum_key_length(&self, length: i32);
 
     fn set_model<'a, P: IsA<TreeModel> + 'a, Q: Into<Option<&'a P>>>(&self, model: Q);
@@ -247,10 +245,6 @@ impl<O: IsA<EntryCompletion> + IsA<glib::object::Object>> EntryCompletionExt for
             ffi::gtk_entry_completion_set_inline_selection(self.to_glib_none().0, inline_selection.to_glib());
         }
     }
-
-    //fn set_match_func<P: Into<Option</*Unimplemented*/Fundamental: Pointer>>>(&self, func: /*Unknown conversion*//*Unimplemented*/EntryCompletionMatchFunc, func_data: P, func_notify: /*Unknown conversion*//*Unimplemented*/DestroyNotify) {
-    //    unsafe { TODO: call ffi::gtk_entry_completion_set_match_func() }
-    //}
 
     fn set_minimum_key_length(&self, length: i32) {
         unsafe {

--- a/src/entry_completion.rs
+++ b/src/entry_completion.rs
@@ -1,0 +1,45 @@
+// Copyright 2013-2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use ffi;
+use glib_ffi;
+use glib::IsA;
+use glib::object::Downcast;
+use glib::translate::*;
+
+use libc::c_char;
+use std::boxed::Box as Box_;
+use std::mem::transmute;
+
+use EntryCompletion;
+use TreeIter;
+
+pub trait EntryCompletionExtManual {
+    fn set_match_func<F: Fn(&Self, &str, &TreeIter) -> bool + 'static>(&self, f: F);
+}
+
+impl<O: IsA<EntryCompletion>> EntryCompletionExtManual for O {
+    fn set_match_func<F: Fn(&Self, &str, &TreeIter) -> bool + 'static>(&self, f: F) {
+        unsafe {
+            let f: Box_<Box_<Fn(&Self, &str, &TreeIter) -> bool + 'static>> = Box_::new(Box_::new(f));
+            let callback = transmute(set_match_func_trampoline::<Self> as usize);
+            ffi::gtk_entry_completion_set_match_func(self.to_glib_none().0,
+                                                     callback,
+                                                     Box_::into_raw(f) as *mut _,
+                                                     None);
+        }
+    }
+}
+
+unsafe extern "C" fn set_match_func_trampoline<P>(this: *mut ffi::GtkEntryCompletion,
+                                                  key: *const c_char,
+                                                  iter: *mut ffi::GtkTreeIter,
+                                                  f: glib_ffi::gpointer)
+                                                  -> glib_ffi::gboolean
+where P: IsA<EntryCompletion> {
+    let f: &&(Fn(&P, &str, &TreeIter) -> bool + 'static) = transmute(f);
+    f(&EntryCompletion::from_glib_borrow(this).downcast_unchecked(),
+      &String::from_glib_none(key),
+      &TreeIter::from_glib_borrow(iter)).to_glib()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@ mod color_chooser;
 mod dialog;
 mod drag_context;
 mod entry_buffer;
+mod entry_completion;
 mod enums;
 mod file_chooser_dialog;
 mod fixed;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,7 @@ pub use color_button::ColorButtonExtManual;
 pub use color_chooser::ColorChooserExtManual;
 pub use dialog::DialogExtManual;
 pub use drag_context::DragContextExtManual;
+pub use entry_completion::EntryCompletionExtManual;
 pub use fixed::FixedExtManual;
 pub use im_context_simple::IMContextSimpleExtManual;
 #[cfg(any(feature = "v3_10", feature = "dox"))]


### PR DESCRIPTION
Fixes #685.

Two things about this implementation:
1. It doesn't take into account the destroy notify
2. It'll certainly be removed "soon" when we'll generate callbacks as well.

cc @EPashkin @sdroege 