### PR TITLE
Implement MSVC compatibility.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ v3_14 = ["v3_12", "gtk-sys/v3_14", "gdk/v3_14"]
 dox = ["gdk/dox", "gtk-sys/dox"]
 futures = ["futures-core-preview", "fragile", "gio/futures"]
 
+[target.'cfg(all(target_os = "windows", target_env = "msvc"))'.build-dependencies]
+vcpkg = "0.2.6"
+
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "^1.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,20 @@
 #[cfg(target_os = "macos")]
 extern crate cc;
 
+#[cfg(all(target_os = "windows", target_env = "msvc"))]
+extern crate vcpkg;
+
+use std::{
+    env,
+    fs::{copy, metadata},
+};
+
 fn main() {
     manage_docs();
     #[cfg(target_os = "macos")]
     build_foreground();
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
+    build_with_vcpkg();
 }
 
 #[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
@@ -31,4 +41,105 @@ fn build_foreground() {
     cc::Build::new().file("src/foreground.m").compile("foreground");
     println!("cargo:rustc-link-lib=framework=AppKit");
     println!("cargo:rustc-link-lib=framework=CoreFoundation");
+}
+
+#[cfg(all(target_os = "windows", target_env = "msvc"))]
+fn build_with_vcpkg() {
+    fn ensure_lib_file_name(library: &vcpkg::Library, src_name: &str, dst_name: &str) {
+        let src_name = format!("{}.lib", &src_name);
+        let dst_name = format!("{}.lib", &dst_name);
+
+        for src_path in &library.found_libs {
+            // see if we can find the library we are looking for
+            if src_path
+                .file_name()
+                .expect("vcpkg found a lib that is not a file")
+                == src_name.as_str()
+            {
+                // put together path for needed lib name
+                let dst_path = src_path
+                    .parent()
+                    .expect("vcpkg found a lib with an invalid path")
+                    .join(&dst_name);
+
+                // check if we really need to copy, maybe it's already there
+                let mut to_copy = true;
+
+                // check if we may not need to replace the file
+                // only if the other file exists
+                if dst_path.exists() {
+                    let src_metadata = metadata(&src_path).expect("file doesn't have metadata");
+                    let dst_metadata = metadata(&dst_path).expect("file doesn't have metadata");
+
+                    // if the OS gives us the last modified time
+                    if let Ok(src_modified) = src_metadata.modified() {
+                        if let Ok(dst_modified) = dst_metadata.modified() {
+                            // if the size and modified time is equal
+                            if src_metadata.len() == dst_metadata.len()
+                                && src_modified == dst_modified
+                            {
+                                // then we dont need to replace
+                                to_copy = false;
+                            }
+                        }
+                    }
+                }
+
+                if to_copy {
+                    // copy file
+                    copy(&src_path, &dst_path).unwrap_or_else(|error| {
+                        panic!(
+                            "copying `{}` to `{}` failed: {}",
+                            src_path.to_string_lossy(),
+                            dst_path.to_string_lossy(),
+                            error
+                        )
+                    });
+                }
+            }
+        }
+    }
+
+    // having `VCPKG_ROOT` is required
+    if let Ok(_) = env::var("VCPKG_ROOT") {
+        // the alternative would be `RUSTFLAGS = "-C target-feature=+crt-static"`
+        // which doesn't work right now
+        env::set_var("VCPKGRS_DYNAMIC", "1");
+
+        match vcpkg::find_package("gtk") {
+            Ok(library) => {
+                // if we found the library, we have to fix some file names for the linker to find
+                ensure_lib_file_name(&library, "gtk-3.0", "gtk-3");
+                ensure_lib_file_name(&library, "gdk-3.0", "gdk-3");
+            }
+            Err(error) => {
+                // tell the user what to do if lib isn't found
+                if let vcpkg::Error::LibNotFound(error) = error {
+                    // first find out the right arch to install
+                    let target_triple = std::env::var("TARGET").expect(
+                    "environment variable `TARGET` is not defined, it should always be passed by cargo",
+                );
+                    let arch;
+
+                    if target_triple == "x86_64-pc-windows-msvc" {
+                        arch = "x64-windows";
+                    } else if target_triple == "i686-pc-windows-msvc" {
+                        arch = "x86-windows";
+                    } else {
+                        panic!("unsupported target triple: {}", target_triple);
+                    }
+
+                    panic!("vcpkg couldn't find a valid installation of the `gtk` package, use `vcpkg install gtk:{}`: {}", arch, error);
+                }
+                // otherwise tell user what the error is
+                else {
+                    panic!("{}", error);
+                }
+            }
+        }
+    } else {
+        panic!(
+            "vcpkg needs to be installed and pointed at by the environment variable `VCPKG_ROOT`"
+        );
+    }
 }


### PR DESCRIPTION
See #702 for more discussions about this.
I got the inspiration from here: https://github.com/kykc/gtk-rs-msvc.

There is very little necessary to make it compile and run:
1. install [vcpkg](https://github.com/Microsoft/vcpkg)
2. `vcpkg install gtk:x64-windows` (or `vcpkg install gtk:x86-windows` respectively)
3. define `VCPKG_ROOT` for [`vcpkg::find_package()`](https://docs.rs/vcpkg/0.2.6/vcpkg/) to work
4. run `vcpkg::find_package("gtk")` to feed the linker with libs
5. copy `gtk-3.0.lib` to `gtk-3.lib` and `gdk-3.0.lib` to `gdk-3.lib`

This PR currently implements step 4. and 5. into `build.rs`.

**Question**
- Should we automatize step 1. and 2. too? I have already tried it and it works splendidly, but may be out of scope for this.

**Pending Tasks if it's decided to implement this**
- [ ] Update https://gtk-rs.org/docs/requirements.html.
- [ ] Document the quirks of the vcpkg version of GTK. One difference that I noticed is that it uses a non-default theme by default.
- [ ] Document some help for dll distribution.