### PR TITLE
Add TreeSelectionExtManual to set selection func

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,7 @@ mod text_buffer;
 mod text_iter;
 mod tree_model_filter;
 mod tree_row_reference;
+mod tree_selection;
 mod tree_sortable;
 mod tree_path;
 mod tree_store;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -31,6 +31,7 @@ pub use pad_controller::PadControllerExtManual;
 pub use switch::SwitchExtManual;
 pub use text_buffer::TextBufferExtManual;
 pub use tree_model_filter::TreeModelFilterExtManual;
+pub use tree_selection::TreeSelectionExtManual;
 pub use tree_sortable::TreeSortableExtManual;
 pub use tree_store::TreeStoreExtManual;
 pub use widget::WidgetExtManual;

--- a/src/tree_selection.rs
+++ b/src/tree_selection.rs
@@ -1,0 +1,66 @@
+// Copyright 2019, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use ffi;
+use ffi::{GtkTreeModel, GtkTreePath, GtkTreeSelection};
+use glib::object::{Cast, IsA};
+use glib::translate::*;
+use glib_ffi::{gboolean, gpointer};
+use std::mem::transmute;
+use {TreeModel, TreePath, TreeSelection};
+
+pub trait TreeSelectionExtManual: 'static {
+    fn set_select_function<F>(&self, f: F)
+    where
+        F: Fn(&Self, &TreeModel, &TreePath, bool) -> bool;
+}
+
+unsafe extern "C" fn trampoline<T>(
+    this: *mut GtkTreeSelection,
+    model: *mut GtkTreeModel,
+    path: *mut GtkTreePath,
+    selected: gboolean,
+    f: gpointer,
+) -> i32
+where
+    T: IsA<TreeSelection>,
+{
+    let f: &&(Fn(&T, &TreeModel, &TreePath, bool) -> bool) = transmute(f);
+    f(
+        &TreeSelection::from_glib_none(this).unsafe_cast(),
+        &from_glib_borrow(model),
+        &from_glib_borrow(path),
+        from_glib(selected),
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn destroy_closure<T>(ptr: gpointer) {
+    Box::<Box<Fn(&T, &TreeModel, &TreePath, bool) -> bool>>::from_raw(ptr as *mut _);
+}
+
+fn into_raw<F, T>(func: F) -> gpointer
+where
+    F: Fn(&T, &TreeModel, &TreePath, bool) -> bool,
+{
+    skip_assert_initialized!();
+    let func: Box<Box<Fn(&T, &TreeModel, &TreePath, bool) -> bool>> = Box::new(Box::new(func));
+    Box::into_raw(func) as gpointer
+}
+
+impl<O: IsA<TreeSelection>> TreeSelectionExtManual for O {
+    fn set_select_function<F>(&self, f: F)
+    where
+        F: Fn(&Self, &TreeModel, &TreePath, bool) -> bool,
+    {
+        unsafe {
+            ffi::gtk_tree_selection_set_select_function(
+                self.as_ref().to_glib_none().0,
+                Some(trampoline::<Self>),
+                into_raw(f),
+                Some(destroy_closure::<Self>),
+            )
+        }
+    }
+}


### PR DESCRIPTION
I noticed after writing this that if I regenerated the bindings from the gir files that this now exists directly in `TreeSelectionExt`. However, I got segfaults every time I tried to use it.

I wasn't sure what the policy was, or if its inclusion was deliberate or something I broke (because I thought it was ignored before), so I figured I'd submit this (which is working fine for me in a project using a gtk-rs from source) in case you wanted the code instead of the auto-generated version.