### PR TITLE
Support non-GNU versions of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIR = gir/target/bin/gir
-GIR_SRC = gir/Cargo.toml gir/Cargo.lock gir/build.rs $(shell find gir/src -name '*.rs')
+GIR_SRC != find gir/src -name '*.rs'
+GIR_SRC += gir/Cargo.toml gir/Cargo.lock gir/build.rs
 GIR_FILES = gir-files/Gtk-3.0.gir
 
 # Run `gir` generating the bindings


### PR DESCRIPTION
I have bmake (NetBSD's make, which is mostly just POSIX like and doesn't support many GNU-isms) installed on most of my machines. The makefile for this project mostly works, but `GIR_SRC` wasn't being set correctly because the `shell` expansion is a GNU-ism.

This sets those files in a more standard way that other versions of Make (including GNU's) will also pick up on.