### PR TITLE
Acquire the default MainContext when initializing GTK

### DIFF
--- a/src/rt.rs
+++ b/src/rt.rs
@@ -96,6 +96,10 @@ pub fn init() -> Result<(), glib::BoolError> {
     }
     unsafe {
         if pre_init() && from_glib(ffi::gtk_init_check(ptr::null_mut(), ptr::null_mut())) {
+            if !glib::MainContext::default().acquire() {
+                return Err(glib_bool_error!("Failed to acquire default main context"));
+            }
+
             set_initialized();
             Ok(())
         }


### PR DESCRIPTION
    It is required for GTK to be able to own the default main context on the
    thread that initialized it, among other things to run its main loop on
    that.
    
    Make this more explicit by already acquiring it here during
    initialization. This also ensures that other API that checks that this
    very thread owns the main context works out of the box.

----

This depends on https://github.com/gtk-rs/glib/pull/447