### PR TITLE
Add a special type for add_tick_callback's return value

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -2026,6 +2026,12 @@ manual_traits = ["WidgetExtManual"]
         [object.function.return]
         nullable = false
     [[object.function]]
+    name = "add_tick_callback"
+    ignore = true
+    [[object.function]]
+    name = "remove_tick_callback"
+    ignore = true
+    [[object.function]]
     name = "add_events"
     ignore = true
     [[object.function]]

--- a/src/auto/widget.rs
+++ b/src/auto/widget.rs
@@ -90,8 +90,6 @@ pub trait WidgetExt: 'static {
 
     fn add_mnemonic_label<P: IsA<Widget>>(&self, label: &P);
 
-    fn add_tick_callback<P: Fn(&Widget, &gdk::FrameClock) -> bool + 'static>(&self, callback: P) -> u32;
-
     fn can_activate_accel(&self, signal_id: u32) -> bool;
 
     fn child_focus(&self, direction: DirectionType) -> bool;
@@ -407,8 +405,6 @@ pub trait WidgetExt: 'static {
     fn remove_accelerator<P: IsA<AccelGroup>>(&self, accel_group: &P, accel_key: u32, accel_mods: gdk::ModifierType) -> bool;
 
     fn remove_mnemonic_label<P: IsA<Widget>>(&self, label: &P);
-
-    fn remove_tick_callback(&self, id: u32);
 
     fn reset_style(&self);
 
@@ -804,26 +800,6 @@ impl<O: IsA<Widget>> WidgetExt for O {
     fn add_mnemonic_label<P: IsA<Widget>>(&self, label: &P) {
         unsafe {
             ffi::gtk_widget_add_mnemonic_label(self.as_ref().to_glib_none().0, label.as_ref().to_glib_none().0);
-        }
-    }
-
-    fn add_tick_callback<P: Fn(&Widget, &gdk::FrameClock) -> bool + 'static>(&self, callback: P) -> u32 {
-        let callback_data: Box_<P> = Box::new(callback);
-        unsafe extern "C" fn callback_func<P: Fn(&Widget, &gdk::FrameClock) -> bool + 'static>(widget: *mut ffi::GtkWidget, frame_clock: *mut gdk_ffi::GdkFrameClock, user_data: glib_ffi::gpointer) -> glib_ffi::gboolean {
-            let widget = from_glib_borrow(widget);
-            let frame_clock = from_glib_borrow(frame_clock);
-            let callback: &P = &*(user_data as *mut _);
-            let res = (*callback)(&widget, &frame_clock);
-            res.to_glib()
-        }
-        let callback = Some(callback_func::<P> as _);
-        unsafe extern "C" fn notify_func<P: Fn(&Widget, &gdk::FrameClock) -> bool + 'static>(data: glib_ffi::gpointer) {
-            let _callback: Box_<P> = Box_::from_raw(data as *mut _);
-        }
-        let destroy_call3 = Some(notify_func::<P> as _);
-        let super_callback0: Box_<P> = callback_data;
-        unsafe {
-            ffi::gtk_widget_add_tick_callback(self.as_ref().to_glib_none().0, callback, Box::into_raw(super_callback0) as *mut _, destroy_call3)
         }
     }
 
@@ -1765,12 +1741,6 @@ impl<O: IsA<Widget>> WidgetExt for O {
     fn remove_mnemonic_label<P: IsA<Widget>>(&self, label: &P) {
         unsafe {
             ffi::gtk_widget_remove_mnemonic_label(self.as_ref().to_glib_none().0, label.as_ref().to_glib_none().0);
-        }
-    }
-
-    fn remove_tick_callback(&self, id: u32) {
-        unsafe {
-            ffi::gtk_widget_remove_tick_callback(self.as_ref().to_glib_none().0, id);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,3 +298,4 @@ pub use response_type::ResponseType;
 pub use socket::Socket;
 pub use target_entry::TargetEntry;
 pub use tree_sortable::SortColumn;
+pub use widget::TickCallbackId;


### PR DESCRIPTION
For safety reasons, the value consumed by remove_tick_callback needs to be created by add_tick_callback. FromGlib and ToGlib are not implemented for the same reason.

First contribution, so I may have missed things.

Fixes #761, cc @EPashkin, @sdroege.