### PR TITLE
builder: Move trait methods to traits

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -495,6 +495,7 @@ manual_traits = ["BuildableExtManual"]
 [[object]]
 name = "Gtk.Builder"
 status = "generate"
+manual_traits = ["BuilderExtManual"]
     [[object.function]]
     pattern = ".+_from_file"
     #path

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,19 +16,26 @@ impl Builder {
         assert_initialized_main_thread!();
         unsafe { from_glib_full(ffi::gtk_builder_new_from_file(file_path.as_ref().to_glib_none().0)) }
     }
+}
 
-    pub fn get_object<T: IsA<Object>>(&self, name: &str) -> Option<T> {
+pub trait BuilderExtManual: 'static {
+    fn get_object<T: IsA<Object>>(&self, name: &str) -> Option<T>;
+    fn add_from_file<T: AsRef<Path>>(&self, file_path: T) -> Result<(), Error>;
+}
+
+impl<O: IsA<Builder>> BuilderExtManual for O {
+    fn get_object<T: IsA<Object>>(&self, name: &str) -> Option<T> {
         unsafe {
             Option::<Object>::from_glib_none(
-                ffi::gtk_builder_get_object(self.to_glib_none().0, name.to_glib_none().0))
+                ffi::gtk_builder_get_object(self.upcast_ref().to_glib_none().0, name.to_glib_none().0))
                 .and_then(|obj| obj.dynamic_cast::<T>().ok())
         }
     }
 
-    pub fn add_from_file<T: AsRef<Path>>(&self, file_path: T) -> Result<(), Error> {
+    fn add_from_file<T: AsRef<Path>>(&self, file_path: T) -> Result<(), Error> {
         unsafe {
             let mut error = ::std::ptr::null_mut();
-            ffi::gtk_builder_add_from_file(self.to_glib_none().0,
+            ffi::gtk_builder_add_from_file(self.upcast_ref().to_glib_none().0,
                                            file_path.as_ref().to_glib_none().0,
                                            &mut error);
             if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,7 @@ pub use auto::traits::*;
 
 pub use app_chooser::AppChooserExt;
 pub use buildable::BuildableExtManual;
+pub use builder::BuilderExtManual;
 pub use cell_renderer_pixbuf::CellRendererPixbufExtManual;
 pub use color_button::ColorButtonExtManual;
 pub use color_chooser::ColorChooserExtManual;


### PR DESCRIPTION
These methods should be implemented on `IsA<Builder>`, not just `Builder`.