### PR TITLE
Reorder "::insert_text()" params according to autogenerated functions

### DIFF
--- a/src/auto/combo_box_text.rs
+++ b/src/auto/combo_box_text.rs
@@ -57,7 +57,7 @@ pub trait ComboBoxTextExt: 'static {
 
     fn insert(&self, position: i32, id: Option<&str>, text: &str);
 
-    fn insert_text(&self, position: i32, text: &str);
+    fn insert_text(&self, text: &str, position: i32);
 
     fn prepend(&self, id: Option<&str>, text: &str);
 
@@ -93,7 +93,7 @@ impl<O: IsA<ComboBoxText>> ComboBoxTextExt for O {
         }
     }
 
-    fn insert_text(&self, position: i32, text: &str) {
+    fn insert_text(&self, text: &str, position: i32) {
         unsafe {
             gtk_sys::gtk_combo_box_text_insert_text(self.as_ref().to_glib_none().0, position, text.to_glib_none().0);
         }

--- a/src/entry_buffer.rs
+++ b/src/entry_buffer.rs
@@ -64,7 +64,7 @@ impl EntryBuffer {
         unsafe { from_glib_none(gtk_sys::gtk_entry_buffer_get_text(self.to_glib_none().0)) }
     }
 
-    pub fn insert_text(&self, position: u16, chars: &str) -> u16 {
+    pub fn insert_text(&self, chars: &str, position: u16) -> u16 {
         unsafe {
             to_u16!(
                 gtk_sys::gtk_entry_buffer_insert_text(self.to_glib_none().0, position as c_uint,


### PR DESCRIPTION
Hi!

During the latest Gnome Hackfest :^) I've noticed what I believe is a tiny inconsistency in the parameters ordering for the same `insert_text` function in different widgets, e.g.:

- (autogenerated) [gtk::EditableExt::insert_text](http://gtk-rs.org/docs/gtk/trait.EditableExt.html#tymethod.insert_text)
- [gtk::ComboBoxTextExt::insert_text](http://gtk-rs.org/docs/gtk/trait.ComboBoxTextExt.html#tymethod.insert_text)
- [gtk::EntryBuffer::insert_text](http://gtk-rs.org/docs/gtk/struct.EntryBuffer.html#method.insert_text)

This is just nitpicking, but I thought it could make sense to respect the parameters ordering from the autogenerated functions (since we have less control on them).

One thing I'm asking for advice: after this change tests don't fail, which I kind of expected.

There may be other functions that could benefit from some uniform signature (but didn't investigate deep enough).

Your thoughts on this?

thanks!