### PR TITLE
Remove unneeded mutability for pango::TabArray

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -941,6 +941,11 @@ status = "generate"
         [[object.function.parameter]]
         name = "event"
         const = true
+    [[object.function]]
+    name = "set_tabs"
+        [[object.function.parameter]]
+        name = "tabs"
+        const = true
     [[object.property]]
     name = "tabs"
     #value pango::TabArray
@@ -1811,6 +1816,11 @@ status = "generate"
     name = "im_context_filter_keypress"
         [[object.function.parameter]]
         name = "event"
+        const = true
+    [[object.function]]
+    name = "set_tabs"
+        [[object.function.parameter]]
+        name = "tabs"
         const = true
     [[object.signal]]
     name = "extend-selection"

--- a/src/auto/entry.rs
+++ b/src/auto/entry.rs
@@ -958,7 +958,7 @@ pub trait EntryExt: 'static {
 
     fn set_progress_pulse_step(&self, fraction: f64);
 
-    fn set_tabs(&self, tabs: &mut pango::TabArray);
+    fn set_tabs(&self, tabs: &pango::TabArray);
 
     fn set_text(&self, text: &str);
 
@@ -1615,9 +1615,9 @@ impl<O: IsA<Entry>> EntryExt for O {
         }
     }
 
-    fn set_tabs(&self, tabs: &mut pango::TabArray) {
+    fn set_tabs(&self, tabs: &pango::TabArray) {
         unsafe {
-            gtk_sys::gtk_entry_set_tabs(self.as_ref().to_glib_none().0, tabs.to_glib_none_mut().0);
+            gtk_sys::gtk_entry_set_tabs(self.as_ref().to_glib_none().0, mut_override(tabs.to_glib_none().0));
         }
     }
 

--- a/src/auto/text_view.rs
+++ b/src/auto/text_view.rs
@@ -808,7 +808,7 @@ pub trait TextViewExt: 'static {
 
     fn set_right_margin(&self, right_margin: i32);
 
-    fn set_tabs(&self, tabs: &mut pango::TabArray);
+    fn set_tabs(&self, tabs: &pango::TabArray);
 
     #[cfg(any(feature = "v3_18", feature = "dox"))]
     fn set_top_margin(&self, top_margin: i32);
@@ -1351,9 +1351,9 @@ impl<O: IsA<TextView>> TextViewExt for O {
         }
     }
 
-    fn set_tabs(&self, tabs: &mut pango::TabArray) {
+    fn set_tabs(&self, tabs: &pango::TabArray) {
         unsafe {
-            gtk_sys::gtk_text_view_set_tabs(self.as_ref().to_glib_none().0, tabs.to_glib_none_mut().0);
+            gtk_sys::gtk_text_view_set_tabs(self.as_ref().to_glib_none().0, mut_override(tabs.to_glib_none().0));
         }
     }
 


### PR DESCRIPTION
Reported in https://github.com/gtk-rs/gir/pull/782

cc @GuillaumeGomez, @sdroege