### PR TITLE
subclass: Add support for subclassing GtkBox

### DIFF
--- a/src/subclass/box_.rs
+++ b/src/subclass/box_.rs
@@ -1,0 +1,10 @@
+use glib::subclass::prelude::*;
+
+use super::container::ContainerImpl;
+use BoxClass;
+
+pub trait BoxImpl: ContainerImpl + 'static {}
+
+unsafe impl<T: ObjectSubclass + BoxImpl> IsSubclassable<T> for BoxClass {
+    fn override_vfuncs(&mut self) {}
+}

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod application;
 pub mod bin;
+pub mod box_;
 pub mod container;
 pub mod event_box;
 pub mod widget;
@@ -11,6 +12,7 @@ pub mod widget;
 pub mod prelude {
     pub use super::application::GtkApplicationImpl;
     pub use super::bin::BinImpl;
+    pub use super::box_::BoxImpl;
     pub use super::container::ContainerImpl;
     pub use super::event_box::EventBoxImpl;
     pub use super::widget::WidgetImpl;


### PR DESCRIPTION
Like subclassing GtkBin, this is an empty trait
and empty `override_vfuncs`.