### PR TITLE
Generate GtkStyleContext get property functions

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -1766,9 +1766,6 @@ status = "ignore"
 name = "Gtk.StyleContext"
 status = "generate"
     [[object.function]]
-    pattern = "get_(style_)?property"
-    ignore = true
-    [[object.function]]
     name = "get_font"
     ignore = true #returning Pango.FontDescription from *const
     [[object.property]]

--- a/src/auto/style_context.rs
+++ b/src/auto/style_context.rs
@@ -3,6 +3,7 @@
 // DO NOT EDIT
 
 use gdk;
+use glib;
 use glib::object::Cast;
 use glib::object::IsA;
 use glib::signal::connect_raw;
@@ -170,6 +171,8 @@ pub trait StyleContextExt: 'static {
 
     fn get_path(&self) -> Option<WidgetPath>;
 
+    fn get_property(&self, property: &str, state: StateFlags) -> glib::Value;
+
     fn get_scale(&self) -> i32;
 
     fn get_screen(&self) -> Option<gdk::Screen>;
@@ -179,6 +182,8 @@ pub trait StyleContextExt: 'static {
     fn get_state(&self) -> StateFlags;
 
     //fn get_style(&self, : /*Unknown conversion*//*Unimplemented*/Fundamental: VarArgs);
+
+    fn get_style_property(&self, property_name: &str, value: &mut glib::Value);
 
     //fn get_style_valist(&self, args: /*Unknown conversion*//*Unimplemented*/Unsupported);
 
@@ -365,6 +370,19 @@ impl<O: IsA<StyleContext>> StyleContextExt for O {
         }
     }
 
+    fn get_property(&self, property: &str, state: StateFlags) -> glib::Value {
+        unsafe {
+            let mut value = glib::Value::uninitialized();
+            gtk_sys::gtk_style_context_get_property(
+                self.as_ref().to_glib_none().0,
+                property.to_glib_none().0,
+                state.to_glib(),
+                value.to_glib_none_mut().0,
+            );
+            value
+        }
+    }
+
     fn get_scale(&self) -> i32 {
         unsafe { gtk_sys::gtk_style_context_get_scale(self.as_ref().to_glib_none().0) }
     }
@@ -397,6 +415,16 @@ impl<O: IsA<StyleContext>> StyleContextExt for O {
     //fn get_style(&self, : /*Unknown conversion*//*Unimplemented*/Fundamental: VarArgs) {
     //    unsafe { TODO: call gtk_sys:gtk_style_context_get_style() }
     //}
+
+    fn get_style_property(&self, property_name: &str, value: &mut glib::Value) {
+        unsafe {
+            gtk_sys::gtk_style_context_get_style_property(
+                self.as_ref().to_glib_none().0,
+                property_name.to_glib_none().0,
+                value.to_glib_none_mut().0,
+            );
+        }
+    }
 
     //fn get_style_valist(&self, args: /*Unknown conversion*//*Unimplemented*/Unsupported) {
     //    unsafe { TODO: call gtk_sys:gtk_style_context_get_style_valist() }


### PR DESCRIPTION
These were ignored previously.

Fixes https://github.com/gtk-rs/gtk/issues/874