### PR TITLE
subclass: Add support for subclassing GtkHeaderBar

### DIFF
--- a/src/subclass/header_bar.rs
+++ b/src/subclass/header_bar.rs
@@ -1,0 +1,10 @@
+use glib::subclass::prelude::*;
+
+use super::container::ContainerImpl;
+use HeaderBarClass;
+
+pub trait HeaderBarImpl: ContainerImpl + 'static {}
+
+unsafe impl<T: ObjectSubclass + HeaderBarImpl> IsSubclassable<T> for HeaderBarClass {
+    fn override_vfuncs(&mut self) {}
+}

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -8,6 +8,7 @@ pub mod bin;
 pub mod box_;
 pub mod container;
 pub mod event_box;
+pub mod header_bar;
 pub mod widget;
 pub mod window;
 
@@ -18,6 +19,7 @@ pub mod prelude {
     pub use super::box_::BoxImpl;
     pub use super::container::ContainerImpl;
     pub use super::event_box::EventBoxImpl;
+    pub use super::header_bar::HeaderBarImpl;
     pub use super::widget::WidgetImpl;
     pub use super::window::WindowImpl;
     pub use gio::subclass::prelude::*;


### PR DESCRIPTION
Like EventBox this is an empty trait and `override_vfuncs`.