### PR TITLE
Get rid of Uninitialized impl for TargetEntry

### DIFF
--- a/src/target_entry.rs
+++ b/src/target_entry.rs
@@ -3,7 +3,6 @@ use glib::translate::*;
 use gtk_sys;
 use libc::c_char;
 use std::ffi::CStr;
-use std::mem;
 use TargetFlags;
 
 #[derive(Clone, Debug)]
@@ -34,14 +33,6 @@ impl TargetEntry {
 
     pub fn get_info(&self) -> u32 {
         self.info
-    }
-}
-
-#[doc(hidden)]
-impl Uninitialized for TargetEntry {
-    #[inline]
-    unsafe fn uninitialized() -> Self {
-        mem::zeroed()
     }
 }
 


### PR DESCRIPTION
It used mem::zeroed() and that causes undefined behaviour here. String
and other types can't be simply zeroed here.

----

This also caused a compiler warning with 1.38.