### PR TITLE
Warn on macos when initializing from non_main_thread

### DIFF
--- a/src/rt.rs
+++ b/src/rt.rs
@@ -10,7 +10,10 @@ use libc::c_uint;
 use std::cell::Cell;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
-use std::thread;
+
+extern "C" {
+    fn pthread_main_np() -> i32;
+}
 
 thread_local! {
     static IS_MAIN_THREAD: Cell<bool> = Cell::new(false)
@@ -67,6 +70,9 @@ pub unsafe fn set_initialized() {
         return;
     } else if is_initialized() {
         panic!("Attempted to initialize GTK from two different threads.");
+    } else if cfg!(target_os = "macos") && pthread_main_np() == 0 {
+        //  OS X has its own notion of the main thread and init must be called on that thread.
+        panic!("Attempted to initialize GTK on OSX from non-main thread");
     }
     gdk::set_initialized();
     INITIALIZED.store(true, Ordering::Release);
@@ -90,9 +96,6 @@ pub fn init() -> Result<(), glib::BoolError> {
         return Ok(());
     } else if is_initialized() {
         panic!("Attempted to initialize GTK from two different threads.");
-    } else if cfg!(target_os = "macos") && thread::current().name() != Some("main") {
-        //  OS X has its own notion of the main thread and init must be called on that thread.
-        panic!("Attempted to initialize GTK on OSX from non-main thread");
     }
     unsafe {
         if from_glib(gtk_sys::gtk_init_check(ptr::null_mut(), ptr::null_mut())) {


### PR DESCRIPTION
Saw that we could do this with pthread, but opted to check the threadname as it was easier to do.
https://users.rust-lang.org/t/guis-and-the-main-thread/2863/22

I also wasn't sure if it belonged in `fn init` or `fn set_initialized` - tossed it in init as initial approach.