### PR TITLE
Make AccelGroup::connect() and ::connect_by_path() more usable

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -527,6 +527,14 @@ status = "generate"
     # It's not a part of public API
     # See https://mail.gnome.org/archives/commits-list/2012-May/msg07052.html
     ignore = true
+    [[object.function]]
+    name = "connect"
+    # Manual, more convenient implementation
+    ignore = true
+    [[object.function]]
+    name = "connect_by_path"
+    # Manual, more convenient implementation
+    ignore = true
 
 [[object]]
 name = "Gtk.Actionable"

--- a/src/accel_group.rs
+++ b/src/accel_group.rs
@@ -1,0 +1,119 @@
+// Copyright 2019, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use gdk;
+use glib;
+use glib::object::{Cast, IsA};
+use glib::translate::*;
+use glib::ToValue;
+use gtk_sys;
+use AccelFlags;
+use AccelGroup;
+
+pub trait AccelGroupExtManual: 'static {
+    fn connect_accel_group<F>(
+        &self,
+        accel_key: u32,
+        accel_mods: gdk::ModifierType,
+        accel_flags: AccelFlags,
+        func: F,
+    ) -> glib::Closure
+    where
+        F: Fn(&Self, &glib::Object, u32, gdk::ModifierType) -> bool + 'static;
+
+    fn connect_accel_group_by_path<F>(&self, accel_path: &str, func: F) -> glib::Closure
+    where
+        F: Fn(&Self, &glib::Object, u32, gdk::ModifierType) -> bool + 'static;
+}
+
+impl<O: IsA<AccelGroup>> AccelGroupExtManual for O {
+    fn connect_accel_group<F>(
+        &self,
+        accel_key: u32,
+        accel_mods: gdk::ModifierType,
+        accel_flags: AccelFlags,
+        func: F,
+    ) -> glib::Closure
+    where
+        F: Fn(&Self, &glib::Object, u32, gdk::ModifierType) -> bool + 'static,
+    {
+        let closure = glib::Closure::new_local(move |values| {
+            assert_eq!(values.len(), 4);
+            let s = values[0]
+                .get::<AccelGroup>()
+                .expect("Wrong argument type for first closure argument")
+                .expect("First closure argument is None");
+            let s = s
+                .downcast::<Self>()
+                .expect("Wrong argument type for first closure argument");
+
+            let obj = values[1]
+                .get::<glib::Object>()
+                .expect("Wrong argument type for second closure argument")
+                .expect("Second closure argument is None");
+            let accel_key = values[2]
+                .get_some::<u32>()
+                .expect("Wrong argument type for third closure argument");
+            let accel_mods = values[3]
+                .get_some::<gdk::ModifierType>()
+                .expect("Wrong argument type for fourth closure argument");
+
+            let ret = func(&s, &obj, accel_key, accel_mods);
+
+            Some(ret.to_value())
+        });
+
+        unsafe {
+            gtk_sys::gtk_accel_group_connect(
+                self.as_ref().to_glib_none().0,
+                accel_key,
+                accel_mods.to_glib(),
+                accel_flags.to_glib(),
+                closure.to_glib_none().0,
+            );
+        }
+
+        closure
+    }
+
+    fn connect_accel_group_by_path<F>(&self, accel_path: &str, func: F) -> glib::Closure
+    where
+        F: Fn(&Self, &glib::Object, u32, gdk::ModifierType) -> bool + 'static,
+    {
+        let closure = glib::Closure::new_local(move |values| {
+            assert_eq!(values.len(), 4);
+            let s = values[0]
+                .get::<AccelGroup>()
+                .expect("Wrong argument type for first closure argument")
+                .expect("First closure argument is None");
+            let s = s
+                .downcast::<Self>()
+                .expect("Wrong argument type for first closure argument");
+            let obj = values[1]
+                .get::<glib::Object>()
+                .expect("Wrong argument type for second closure argument")
+                .expect("Second closure argument is None");
+            let accel_key = values[2]
+                .get_some::<u32>()
+                .expect("Wrong argument type for third closure argument");
+            let accel_mods = values[3]
+                .get_some::<gdk::ModifierType>()
+                .expect("Wrong argument type for fourth closure argument");
+
+            let ret = func(&s, &obj, accel_key, accel_mods);
+
+            Some(ret.to_value())
+        });
+
+        unsafe {
+            gtk_sys::gtk_accel_group_connect_by_path(
+                self.as_ref().to_glib_none().0,
+                accel_path.to_glib_none().0,
+                closure.to_glib_none().0,
+            );
+        }
+
+        closure
+    }
+}

--- a/src/auto/accel_group.rs
+++ b/src/auto/accel_group.rs
@@ -17,7 +17,6 @@ use libc;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
-use AccelFlags;
 
 glib_wrapper! {
     pub struct AccelGroup(Object<gtk_sys::GtkAccelGroup, gtk_sys::GtkAccelGroupClass, AccelGroupClass>);
@@ -59,16 +58,6 @@ pub trait AccelGroupExt: 'static {
         accel_key: u32,
         accel_mods: gdk::ModifierType,
     ) -> bool;
-
-    fn connect(
-        &self,
-        accel_key: u32,
-        accel_mods: gdk::ModifierType,
-        accel_flags: AccelFlags,
-        closure: &glib::Closure,
-    );
-
-    fn connect_by_path(&self, accel_path: &str, closure: &glib::Closure);
 
     fn disconnect(&self, closure: Option<&glib::Closure>) -> bool;
 
@@ -120,34 +109,6 @@ impl<O: IsA<AccelGroup>> AccelGroupExt for O {
                 accel_key,
                 accel_mods.to_glib(),
             ))
-        }
-    }
-
-    fn connect(
-        &self,
-        accel_key: u32,
-        accel_mods: gdk::ModifierType,
-        accel_flags: AccelFlags,
-        closure: &glib::Closure,
-    ) {
-        unsafe {
-            gtk_sys::gtk_accel_group_connect(
-                self.as_ref().to_glib_none().0,
-                accel_key,
-                accel_mods.to_glib(),
-                accel_flags.to_glib(),
-                closure.to_glib_none().0,
-            );
-        }
-    }
-
-    fn connect_by_path(&self, accel_path: &str, closure: &glib::Closure) {
-        unsafe {
-            gtk_sys::gtk_accel_group_connect_by_path(
-                self.as_ref().to_glib_none().0,
-                accel_path.to_glib_none().0,
-                closure.to_glib_none().0,
-            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ mod rt;
 #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
 mod auto;
 
+mod accel_group;
 mod app_chooser;
 mod application;
 mod application_window;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub use glib::prelude::*;
 
 pub use auto::traits::*;
 
+pub use accel_group::AccelGroupExtManual;
 pub use app_chooser::AppChooserExt;
 pub use buildable::BuildableExtManual;
 pub use builder::BuilderExtManual;


### PR DESCRIPTION
By renaming it to connect_accel_group() for preventing conflicts with
Object::connect() and by taking a normal Rust closure with fixed types
as arguments instead of a generic glib::Closure.

Return the generated glib::Closure as it is required for usage with a
few of the other AccelGroup and AccelLabel functions.

Fixes https://github.com/gtk-rs/gtk/issues/913

----

CC @upsuper does this work better for you?