### PR TITLE
Fix an ownership issue

### DIFF
--- a/src/subclass/widget.rs
+++ b/src/subclass/widget.rs
@@ -506,11 +506,11 @@ impl<T: WidgetImpl + ObjectImpl> WidgetImplExt for T {
             let data = self.get_type_data();
             let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkWidgetClass;
             if let Some(f) = (*parent_class).dispatch_child_properties_changed {
-                let pspecs_ptr = pspecs
+                let mut pspecs_array = pspecs
                     .iter()
                     .map(|p| p.to_glib_none().0)
-                    .collect::<Vec<_>>()
-                    .as_mut_ptr();
+                    .collect::<Vec<_>>();
+                let pspecs_ptr = pspecs_array.as_mut_ptr();
                 f(widget.to_glib_none().0, pspecs.len() as u32, pspecs_ptr)
             }
         }


### PR DESCRIPTION
Without this I get these valgrind errors (or a crash without valgrind, that cause also gdb to crash)

````
==1466829== Invalid read of size 8
==1466829==    at 0x52B0189: gtk_widget_dispatch_child_properties_changed (gtkwidget.c:4491)
==1466829==    by 0x1263B9: &lt;T as gtk::subclass::widget::WidgetImplExt&gt;::parent_dispatch_child_properties_changed ()
==1466829==    by 0x123091: gtk::subclass::widget::WidgetImpl::dispatch_child_properties_changed ()
==1466829==    by 0x131A4A: gtk::subclass::widget::widget_dispatch_child_properties_changed ()
==1466829==    by 0x52B28FF: g_object_notify_queue_thaw (gobjectnotifyqueue.c:136)
==1466829==    by 0x52B28FF: gtk_widget_thaw_child_notify (gtkwidget.c:4565)
==1466829==    by 0x5051042: gtk_box_pack (gtkbox.c:1561)
==1466829==    by 0x118673: &lt;O as gtk::auto::box_::BoxExt&gt;::pack_start (box_.rs:539)
==1466829==    by 0x118B5B: widget_test::main ()
==1466829==    by 0x11885F: std::rt::lang_start::{{closure}} ()
==1466829==    by 0x164312: std::panicking::try::do_call (in /home/hub/source/niepce/target/debug/examples/widget-test)
==1466829==    by 0x165B19: __rust_maybe_catch_panic (in /home/hub/source/niepce/target/debug/examples/widget-test)
==1466829==    by 0x164D8C: std::rt::lang_start_internal (in /home/hub/source/niepce/target/debug/examples/widget-test)
==1466829==  Address 0x17c119a0 is 0 bytes inside a block of size 16 free'd
==1466829==    at 0x483AA0C: free (vg_replace_malloc.c:540)
==1466829==    by 0x14B572: alloc::alloc::dealloc ()
==1466829==    by 0x14B3F9: &lt;alloc::alloc::Global as core::alloc::Alloc&gt;::dealloc ()
==1466829==    by 0x143638: alloc::raw_vec::RawVec&lt;T,A&gt;::dealloc_buffer (raw_vec.rs:742)
==1466829==    by 0x146FEE: &lt;alloc::raw_vec::RawVec&lt;T,A&gt; as core::ops::drop::Drop&gt;::drop (raw_vec.rs:751)
==1466829==    by 0x12E96E: core::ptr::real_drop_in_place ()
==1466829==    by 0x12F9D1: core::ptr::real_drop_in_place ()
==1466829==    by 0x126335: &lt;T as gtk::subclass::widget::WidgetImplExt&gt;::parent_dispatch_child_properties_changed ()
==1466829==    by 0x123091: gtk::subclass::widget::WidgetImpl::dispatch_child_properties_changed ()
==1466829==    by 0x131A4A: gtk::subclass::widget::widget_dispatch_child_properties_changed ()
==1466829==    by 0x52B28FF: g_object_notify_queue_thaw (gobjectnotifyqueue.c:136)
==1466829==    by 0x52B28FF: gtk_widget_thaw_child_notify (gtkwidget.c:4565)
==1466829==    by 0x5051042: gtk_box_pack (gtkbox.c:1561)
==1466829==  Block was alloc'd at
==1466829==    at 0x483980B: malloc (vg_replace_malloc.c:309)
==1466829==    by 0x14B50B: alloc::alloc::alloc ()
==1466829==    by 0x14B391: &lt;alloc::alloc::Global as core::alloc::Alloc&gt;::alloc ()
==1466829==    by 0x145107: alloc::raw_vec::RawVec&lt;T,A&gt;::reserve_internal (raw_vec.rs:695)
==1466829==    by 0x146D19: alloc::raw_vec::RawVec&lt;T,A&gt;::reserve (raw_vec.rs:520)
==1466829==    by 0x140DE9: alloc::vec::Vec&lt;T&gt;::reserve ()
==1466829==    by 0x12AB08: &lt;alloc::vec::Vec&lt;T&gt; as alloc::vec::SpecExtend&lt;T,I&gt;&gt;::spec_extend ()
==1466829==    by 0x12AD10: &lt;alloc::vec::Vec&lt;T&gt; as alloc::vec::SpecExtend&lt;T,I&gt;&gt;::from_iter ()
==1466829==    by 0x12AE0C: &lt;alloc::vec::Vec&lt;T&gt; as core::iter::traits::collect::FromIterator&lt;T&gt;&gt;::from_iter ()
==1466829==    by 0x12FAA4: core::iter::traits::iterator::Iterator::collect ()
==1466829==    by 0x126302: &lt;T as gtk::subclass::widget::WidgetImplExt&gt;::parent_dispatch_child_properties_changed ()
==1466829==    by 0x123091: gtk::subclass::widget::WidgetImpl::dispatch_child_properties_changed ()
==1466829== 
==1466829== 
````