### PR TITLE
add basic subclassing functionality for treeview

### DIFF
--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -23,6 +23,7 @@ pub mod fixed;
 pub mod header_bar;
 pub mod icon_view;
 pub mod stack;
+pub mod tree_view;
 pub mod widget;
 pub mod window;
 
@@ -48,6 +49,7 @@ pub mod prelude {
     pub use super::header_bar::HeaderBarImpl;
     pub use super::icon_view::{IconViewImpl, IconViewImplExt};
     pub use super::stack::StackImpl;
+    pub use super::tree_view::TreeViewImpl;
     pub use super::widget::{WidgetImpl, WidgetImplExt};
     pub use super::window::{WindowImpl, WindowImplExt};
     pub use gio::subclass::prelude::*;

--- a/src/subclass/tree_view.rs
+++ b/src/subclass/tree_view.rs
@@ -1,0 +1,13 @@
+use glib::subclass::prelude::*;
+
+use super::container::ContainerImpl;
+use ContainerClass;
+use TreeViewClass;
+
+pub trait TreeViewImpl: ContainerImpl + 'static {}
+
+unsafe impl<T: ObjectSubclass + ContainerImpl> IsSubclassable<T> for TreeViewClass {
+    fn override_vfuncs(&mut self) {
+        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+    }
+}


### PR DESCRIPTION
This adds the possibility to subclass TreeView. It does not, however, enable overriding subclasses since:
1. I can't figure out which ones I would need to implement. The generated bindings seem very illogical in that respect.
2. Most of what these methods do can still be done by connecting to signals.

Would it make sense to provide 'stub' subclassing Impls for all other widgets as well?