### PR TITLE
Add gtk::Socket and gtk::Plug subclassing support

### DIFF
--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -22,6 +22,10 @@ pub mod event_box;
 pub mod fixed;
 pub mod header_bar;
 pub mod icon_view;
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
+pub mod plug;
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
+pub mod socket;
 pub mod stack;
 pub mod tree_view;
 pub mod widget;
@@ -48,6 +52,10 @@ pub mod prelude {
     pub use super::fixed::FixedImpl;
     pub use super::header_bar::HeaderBarImpl;
     pub use super::icon_view::{IconViewImpl, IconViewImplExt};
+    #[cfg(any(gdk_backend = "x11", feature = "dox"))]
+    pub use super::plug::{PlugImpl, PlugImplExt};
+    #[cfg(any(gdk_backend = "x11", feature = "dox"))]
+    pub use super::socket::{SocketImpl, SocketImplExt};
     pub use super::stack::StackImpl;
     pub use super::tree_view::TreeViewImpl;
     pub use super::widget::{WidgetImpl, WidgetImplExt};

--- a/src/subclass/plug.rs
+++ b/src/subclass/plug.rs
@@ -1,0 +1,55 @@
+// Copyright 2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::subclass::prelude::*;
+
+use glib::translate::*;
+
+use super::window::WindowImpl;
+use Plug;
+use PlugClass;
+use WindowClass;
+
+pub trait PlugImpl: PlugImplExt + WindowImpl + 'static {
+    fn embedded(&self, plug: &Plug) {
+        self.parent_embedded(plug)
+    }
+}
+
+pub trait PlugImplExt {
+    fn parent_embedded(&self, plug: &Plug);
+}
+
+impl<T: PlugImpl + ObjectImpl> PlugImplExt for T {
+    fn parent_embedded(&self, plug: &Plug) {
+        unsafe {
+            let data = self.get_type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkPlugClass;
+            if let Some(f) = (*parent_class).embedded {
+                f(plug.to_glib_none().0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: ObjectSubclass + PlugImpl> IsSubclassable<T> for PlugClass {
+    fn override_vfuncs(&mut self) {
+        <WindowClass as IsSubclassable<T>>::override_vfuncs(self);
+        unsafe {
+            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkPlugClass);
+            klass.embedded = Some(plug_embedded::<T>);
+        }
+    }
+}
+
+unsafe extern "C" fn plug_embedded<T: ObjectSubclass>(ptr: *mut gtk_sys::GtkPlug)
+where
+    T: PlugImpl,
+{
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Plug> = from_glib_borrow(ptr);
+
+    imp.embedded(&wrap)
+}

--- a/src/subclass/socket.rs
+++ b/src/subclass/socket.rs
@@ -1,0 +1,87 @@
+// Copyright 2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::subclass::prelude::*;
+
+use glib::translate::*;
+
+use super::container::ContainerImpl;
+use crate::Inhibit;
+use ContainerClass;
+use Socket;
+use SocketClass;
+
+pub trait SocketImpl: SocketImplExt + ContainerImpl + 'static {
+    fn plug_added(&self, socket: &Socket) {
+        self.parent_plug_added(socket)
+    }
+
+    fn plug_removed(&self, socket: &Socket) -> Inhibit {
+        self.parent_plug_removed(socket)
+    }
+}
+
+pub trait SocketImplExt {
+    fn parent_plug_added(&self, socket: &Socket);
+    fn parent_plug_removed(&self, socket: &Socket) -> Inhibit;
+}
+
+impl<T: SocketImpl + ObjectImpl> SocketImplExt for T {
+    fn parent_plug_added(&self, socket: &Socket) {
+        unsafe {
+            let data = self.get_type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkSocketClass;
+            if let Some(f) = (*parent_class).plug_added {
+                f(socket.to_glib_none().0)
+            }
+        }
+    }
+
+    fn parent_plug_removed(&self, socket: &Socket) -> Inhibit {
+        unsafe {
+            let data = self.get_type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkSocketClass;
+            if let Some(f) = (*parent_class).plug_removed {
+                Inhibit(from_glib(f(socket.to_glib_none().0)))
+            } else {
+                Inhibit(false)
+            }
+        }
+    }
+}
+
+unsafe impl<T: ObjectSubclass + SocketImpl> IsSubclassable<T> for SocketClass {
+    fn override_vfuncs(&mut self) {
+        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+        unsafe {
+            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkSocketClass);
+            klass.plug_added = Some(socket_plug_added::<T>);
+            klass.plug_removed = Some(socket_plug_removed::<T>);
+        }
+    }
+}
+
+unsafe extern "C" fn socket_plug_added<T: ObjectSubclass>(ptr: *mut gtk_sys::GtkSocket)
+where
+    T: SocketImpl,
+{
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Socket> = from_glib_borrow(ptr);
+
+    imp.plug_added(&wrap)
+}
+
+unsafe extern "C" fn socket_plug_removed<T: ObjectSubclass>(
+    ptr: *mut gtk_sys::GtkSocket,
+) -> glib_sys::gboolean
+where
+    T: SocketImpl,
+{
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Socket> = from_glib_borrow(ptr);
+
+    imp.plug_removed(&wrap).to_glib()
+}


### PR DESCRIPTION
The Socket class only has two additional signals over a container,
so it's a pretty trivial subclass.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>