### PR TITLE
gdk_backend config flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ dox = ["gdk/dox", "gtk-sys/dox"]
 [package.metadata.docs.rs]
 features = ["dox", "embed-lgpl-docs"]
 
+[build-dependencies]
+pkg-config = "0.3.7"
+
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "^1.0"
 

--- a/Gir.toml
+++ b/Gir.toml
@@ -1535,7 +1535,7 @@ status = "generate"
 [[object]]
 name = "Gtk.Plug"
 status = "generate"
-cfg_condition = "all(not(windows),not(target_os = \"macos\"))"
+cfg_condition = "gdk_backend = \"x11\""
 
 [[object]]
 name = "Gtk.Popover"
@@ -1748,7 +1748,7 @@ version = "3.20"
 [[object]]
 name = "Gtk.Socket"
 status = "generate"
-cfg_condition = "all(not(windows),not(target_os = \"macos\"))"
+cfg_condition = "gdk_backend = \"x11\""
 trait_name = "GtkSocketExt"
 
 [[object]]

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ fn main() {
     manage_docs();
     #[cfg(target_os = "macos")]
     build_foreground();
+    check_features();
 }
 
 #[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
@@ -28,4 +29,18 @@ fn build_foreground() {
         .compile("foreground");
     println!("cargo:rustc-link-lib=framework=AppKit");
     println!("cargo:rustc-link-lib=framework=CoreFoundation");
+}
+
+fn check_features() {
+    // The pkg-config file defines a `targets` variable listing the
+    // various backends that gdk (yes, gdk) was compiled for.
+    // We extract that and create gdk_backend="x11" and the like
+    // as configuration variables.
+    // For reference, the backend set at time of writing consists of:
+    // x11 win32 quartz broadway wayland
+    if let Ok(targets) = pkg_config::get_variable("gtk+-3.0", "targets") {
+        for target in targets.split_whitespace() {
+            println!("cargo:rustc-cfg=gdk_backend=\"{}\"", target);
+        }
+    }
 }

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -588,13 +588,13 @@ mod places_sidebar;
 pub use self::places_sidebar::PlacesSidebarBuilder;
 pub use self::places_sidebar::{PlacesSidebar, PlacesSidebarClass};
 
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 mod plug;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::plug::PlugBuilder;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::plug::PlugExt;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::plug::{Plug, PlugClass, NONE_PLUG};
 
 mod popover;
@@ -757,13 +757,13 @@ pub use self::size_group::SizeGroupBuilder;
 pub use self::size_group::SizeGroupExt;
 pub use self::size_group::{SizeGroup, SizeGroupClass, NONE_SIZE_GROUP};
 
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 mod socket;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::socket::GtkSocketExt;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::socket::SocketBuilder;
-#[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+#[cfg(any(gdk_backend = "x11", feature = "dox"))]
 pub use self::socket::{Socket, SocketClass, NONE_SOCKET};
 
 mod spin_button;
@@ -1331,7 +1331,7 @@ pub mod traits {
     pub use super::GtkListStoreExt;
     pub use super::GtkMenuExt;
     pub use super::GtkMenuItemExt;
-    #[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+    #[cfg(any(gdk_backend = "x11", feature = "dox"))]
     pub use super::GtkSocketExt;
     pub use super::GtkWindowExt;
     pub use super::HeaderBarExt;
@@ -1362,7 +1362,7 @@ pub mod traits {
     pub use super::OrientableExt;
     pub use super::OverlayExt;
     pub use super::PanedExt;
-    #[cfg(any(all(not(windows), not(target_os = "macos")), feature = "dox"))]
+    #[cfg(any(gdk_backend = "x11", feature = "dox"))]
     pub use super::PlugExt;
     pub use super::PopoverExt;
     #[cfg(any(feature = "v3_16", feature = "dox"))]


### PR DESCRIPTION
This is a proposed approach for better handling of targets.  The pkg-config file defines a targets variable which is whitespace separated.  This PR consumes that in `build.rs` and sets `target="x11"` and friends as config values.

To demonstrate its use, this then switches `gtk::Plug` and `gtk::Socket` to be predicated on `target="x11"` rather than `all(not(windows), not(target_os = "macos"))`

@sdroege What do you think of this as an approach?  If considered good, it should probably be spread to `gtk-sys` and possibly other crates.