### PR TITLE
Don't include LGPL docs in the docs if both embed-lgpl-docs and purge…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,10 @@ fn main() {
     check_features();
 }
 
-#[cfg(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))]
+#[cfg(all(
+    any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"),
+    not(all(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))
+))]
 fn manage_docs() {
     extern crate lgpl_docs;
     const PATH: &str = "src";
@@ -19,7 +22,10 @@ fn manage_docs() {
     }
 }
 
-#[cfg(not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs")))]
+#[cfg(any(
+    all(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"),
+    not(any(feature = "embed-lgpl-docs", feature = "purge-lgpl-docs"))
+))]
 fn manage_docs() {}
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
…-lgpl-docs features are selected

This makes usage of RLS/rust-analyzer on the repository much faster and
less annoying as the docs don't have to be included and removed on every
change.

----
CC @EPashkin @GuillaumeGomez 