### PR TITLE
Let Widget::hide_on_delete return Inhibit

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -2349,6 +2349,10 @@ manual_traits = ["WidgetExtManual"]
         [[object.function.parameter]]
         name = "allocation"
         const = true
+    [[object.function]]
+    name = "hide_on_delete"
+    ignore = true
+    doc_trait_name = "WidgetExtManual"
     [[object.signal]]
     name = "button-press-event"
     inhibit = true

--- a/Gir.toml
+++ b/Gir.toml
@@ -2351,6 +2351,7 @@ manual_traits = ["WidgetExtManual"]
         const = true
     [[object.function]]
     name = "hide_on_delete"
+    # return Inhibit instead of bool
     ignore = true
     doc_trait_name = "WidgetExtManual"
     [[object.signal]]

--- a/src/auto/widget.rs
+++ b/src/auto/widget.rs
@@ -359,8 +359,6 @@ pub trait WidgetExt: 'static {
 
     fn hide(&self);
 
-    fn hide_on_delete(&self) -> bool;
-
     fn in_destruction(&self) -> bool;
 
     fn init_template(&self);
@@ -2043,14 +2041,6 @@ impl<O: IsA<Widget>> WidgetExt for O {
     fn hide(&self) {
         unsafe {
             gtk_sys::gtk_widget_hide(self.as_ref().to_glib_none().0);
-        }
-    }
-
-    fn hide_on_delete(&self) -> bool {
-        unsafe {
-            from_glib(gtk_sys::gtk_widget_hide_on_delete(
-                self.as_ref().to_glib_none().0,
-            ))
         }
     }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -70,6 +70,8 @@ pub trait WidgetExtManual: 'static {
     /// you must *NOT* query the widget's state subsequently.  Do not call this
     /// yourself unless you really mean to.
     unsafe fn destroy(&self);
+
+    fn hide_on_delete(&self) -> Inhibit;
 }
 
 impl<O: IsA<Widget>> WidgetExtManual for O {
@@ -252,5 +254,13 @@ impl<O: IsA<Widget>> WidgetExtManual for O {
 
     unsafe fn destroy(&self) {
         gtk_sys::gtk_widget_destroy(self.as_ref().to_glib_none().0);
+    }
+
+    fn hide_on_delete(&self) -> Inhibit {
+        unsafe {
+            Inhibit(from_glib(gtk_sys::gtk_widget_hide_on_delete(
+                self.as_ref().to_glib_none().0,
+            )))
+        }
     }
 }


### PR DESCRIPTION
Currently it's not possible to pass this directly to `connect_delete_event()`, because `hide_on_delete()` only accepts one argument. But that also seems to be the case for the C API. That's why I left it like that.

https://developer.gnome.org/gtk3/stable/GtkWidget.html#GtkWidget-delete-event

Closes #1008